### PR TITLE
[api] docs: Auth, Member 스웨거 문서화

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/api/src/main/java/team/pickz/api/domain/member/presentation/MemberController.java
+++ b/api/src/main/java/team/pickz/api/domain/member/presentation/MemberController.java
@@ -12,7 +12,7 @@ import team.pickz.api.global.annotation.MemberId;
 @RequiredArgsConstructor
 @RequestMapping("/members")
 @RestController
-public class MemberController {
+public class MemberController implements MemberDocsController {
 
     private final MemberService memberService;
 

--- a/api/src/main/java/team/pickz/api/domain/member/presentation/MemberDocsController.java
+++ b/api/src/main/java/team/pickz/api/domain/member/presentation/MemberDocsController.java
@@ -1,0 +1,28 @@
+package team.pickz.api.domain.member.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import team.pickz.api.domain.member.application.dto.response.MemberInfoResponse;
+import team.pickz.api.global.annotation.MemberId;
+
+@Tag(name = "Member", description = "회원 관련 API")
+@RequestMapping("/members")
+public interface MemberDocsController {
+
+    @Operation(
+            summary = "내 정보 조회",
+            description = "현재 로그인한 사용자의 정보를 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+    })
+    @GetMapping("/me")
+    ResponseEntity<MemberInfoResponse> getMyInfo(@MemberId Long memberId);
+
+}

--- a/api/src/main/java/team/pickz/api/global/annotation/MemberId.java
+++ b/api/src/main/java/team/pickz/api/global/annotation/MemberId.java
@@ -1,10 +1,13 @@
 package team.pickz.api.global.annotation;
 
+import io.swagger.v3.oas.annotations.Parameter;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+@Parameter(hidden = true)
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface MemberId {

--- a/api/src/main/java/team/pickz/api/global/auth/presentation/AuthDocsController.java
+++ b/api/src/main/java/team/pickz/api/global/auth/presentation/AuthDocsController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -19,9 +20,11 @@ public interface AuthDocsController {
     @Operation(summary = "토큰 재발급", description = "access 토큰 만료 시 refresh 토큰으로 재발급합니다.")
     @Parameter(name = "refresh_token", description = "쿠키에 저장된 리프레시 토큰", in = ParameterIn.COOKIE, required = true)
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "토큰 발급 성공")
+            @ApiResponse(responseCode = "200", description = "토큰 발급 성공"),
+            @ApiResponse(responseCode = "401", description = "리프레시 토큰 누락/유효하지 않음")
     })
-    @PostMapping("/reissue")
+    @SecurityRequirements(value = {})
+    @PostMapping("/token")
     ResponseEntity<Void> reissue(HttpServletRequest request, HttpServletResponse response);
 
 }

--- a/api/src/main/java/team/pickz/api/global/auth/presentation/AuthDocsController.java
+++ b/api/src/main/java/team/pickz/api/global/auth/presentation/AuthDocsController.java
@@ -1,0 +1,27 @@
+package team.pickz.api.global.auth.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Tag(name = "Auth", description = "인증 관련 API")
+@RequestMapping("/auths")
+public interface AuthDocsController {
+
+    @Operation(summary = "토큰 재발급", description = "access 토큰 만료 시 refresh 토큰으로 재발급합니다.")
+    @Parameter(name = "refresh_token", description = "쿠키에 저장된 리프레시 토큰", in = ParameterIn.COOKIE, required = true)
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "토큰 발급 성공")
+    })
+    @PostMapping("/reissue")
+    ResponseEntity<Void> reissue(HttpServletRequest request, HttpServletResponse response);
+
+}

--- a/api/src/main/java/team/pickz/api/global/config/SwaggerConfig.java
+++ b/api/src/main/java/team/pickz/api/global/config/SwaggerConfig.java
@@ -1,0 +1,73 @@
+package team.pickz.api.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class SwaggerConfig {
+
+    private static final String HEADER_AUTH_NAME = "AccessToken_Header";
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(apiInfo())
+                .servers(initializeServers())
+                .components(authComponents())
+                .addSecurityItem(apiSecurityRequirement());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("Pick:Z API")
+                .description(
+                        """
+                        Pick:Z API 문서입니다.
+                        
+                        ### 소셜 로그인 안내
+                        이 API는 OAuth 기반 소셜 로그인을 사용합니다.
+                        - 별도의 API 엔드포인트 없음
+                        - Spring Security 필터에서 처리
+                        
+                        #### 로그인 흐름
+                        1. /api/oauth2/authorization/naver 호출
+                        2. 소셜 로그인 진행
+                        3. 서버에서 JWT 발급
+                        
+                        ### Swagger에서는 Header 방식으로 API 테스트 진행
+                        
+                        - 'Authorize' 버튼을 눌러 발급받은 JWT를 'Bearer {token}' 형식으로 입력하여 테스트할 수 있습니다.
+                        """
+                );
+    }
+
+    private List<Server> initializeServers() {
+        return List.of(
+                new Server().url("http://localhost:8080/api").description("Local Server"),
+                new Server().url("https://pickz.co.kr/api").description("Prod Server")
+        );
+    }
+
+    private Components authComponents() {
+        return new Components()
+                .addSecuritySchemes(HEADER_AUTH_NAME, new SecurityScheme()
+                        .name("Authorization")
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT"));
+    }
+
+    private SecurityRequirement apiSecurityRequirement() {
+        return new SecurityRequirement()
+                .addList(HEADER_AUTH_NAME);
+    }
+
+}


### PR DESCRIPTION
## 관련 이슈

- Closes #10 

## 작업 내용

> 이번 PR에서 작업한 내용을 작성해주세요.

- Auth, Member 스웨거 문서화 작업 진행

## 특이사항

> 후속 작업, 영향 범위, 주의사항이 있으면 작성해주세요.

-

## 추가 정보

> UI 변경, 요청/응답 예시, 스크린샷 등이 있다면 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 통합된 Swagger UI 기반 API 문서 시스템 추가로 엔드포인트를 탐색하고 테스트 가능.
  * 회원 정보 조회 및 토큰 재발급 관련 API가 문서화되어 사용 흐름 확인 가능.
  * API 문서에서 Bearer 토큰 기반 인증이 표시되어 인증 테스트 지원.
  * 내부 식별자(memberId) 파라미터는 문서에서 숨겨져 노출 최소화.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->