### PR TITLE
[api] feat: 치지직 API 연동 및 스트리머 검색 기능 구현

### DIFF
--- a/api/src/main/java/team/pickz/api/domain/streamer/application/StreamerSearchService.java
+++ b/api/src/main/java/team/pickz/api/domain/streamer/application/StreamerSearchService.java
@@ -1,14 +1,12 @@
 package team.pickz.api.domain.streamer.application;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.pickz.api.domain.streamer.application.dto.StreamerSearchResponse;
 import team.pickz.api.domain.streamer.domain.StreamerRepository;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -17,15 +15,15 @@ public class StreamerSearchService {
 
     private final StreamerRepository streamerRepository;
 
-    public Page<StreamerSearchResponse> searchByKeyword(String keyword, int page, int size) {
+    public List<StreamerSearchResponse> searchByKeyword(String keyword) {
         if(keyword == null || keyword.trim().isEmpty()) {
-            return Page.empty();
+            return List.of();
         }
 
-        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "channelName"));
-
-        return streamerRepository.findByChannelNameContainingIgnoreCase(keyword.trim(), pageable)
-                .map(StreamerSearchResponse::from);
+        return streamerRepository.findTop20ByChannelNameContainingIgnoreCaseOrderByChannelNameAsc(keyword.trim())
+                .stream()
+                .map(StreamerSearchResponse::from)
+                .toList();
     }
 
 }

--- a/api/src/main/java/team/pickz/api/domain/streamer/application/StreamerSearchService.java
+++ b/api/src/main/java/team/pickz/api/domain/streamer/application/StreamerSearchService.java
@@ -1,0 +1,31 @@
+package team.pickz.api.domain.streamer.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.pickz.api.domain.streamer.application.dto.StreamerSearchResponse;
+import team.pickz.api.domain.streamer.domain.StreamerRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StreamerSearchService {
+
+    private final StreamerRepository streamerRepository;
+
+    public Page<StreamerSearchResponse> searchByKeyword(String keyword, int page, int size) {
+        if(keyword == null || keyword.trim().isEmpty()) {
+            return Page.empty();
+        }
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "channelName"));
+
+        return streamerRepository.findByChannelNameContainingIgnoreCase(keyword.trim(), pageable)
+                .map(StreamerSearchResponse::from);
+    }
+
+}

--- a/api/src/main/java/team/pickz/api/domain/streamer/application/StreamerSyncService.java
+++ b/api/src/main/java/team/pickz/api/domain/streamer/application/StreamerSyncService.java
@@ -1,0 +1,59 @@
+package team.pickz.api.domain.streamer.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.pickz.api.domain.streamer.domain.Streamer;
+import team.pickz.api.domain.streamer.domain.StreamerRepository;
+import team.pickz.api.infra.chzzk.client.ChzzkClient;
+import team.pickz.api.infra.chzzk.dto.ChzzkChannelResponse;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class StreamerSyncService {
+
+    private final ChzzkClient chzzkClient;
+    private final StreamerRepository streamerRepository;
+    private static final int CHUNK_SIZE = 20;
+
+    @Transactional
+    public void syncStreamers(List<String> targetChannelIds) {
+        List<List<String>> partitionedIds = partitionList(targetChannelIds, CHUNK_SIZE);
+
+        for(List<String> chunk : partitionedIds) {
+            List<ChzzkChannelResponse> externalChannels = chzzkClient.getChannels(chunk);
+
+            List<Streamer> existingStreamers = streamerRepository.findByChannelIdIn(chunk);
+            Map<String, Streamer> existingMap = existingStreamers.stream()
+                    .collect(Collectors.toMap(Streamer::getChannelId, s -> s));
+
+            List<Streamer> toSave = new ArrayList<>();
+            for (ChzzkChannelResponse ext : externalChannels) {
+                Streamer existing = existingMap.get(ext.channelId());
+                if (existing != null) {
+                    existing.updateProfile(ext.channelName(), ext.channelName(), ext.channelImageUrl());
+                } else {
+                    toSave.add(Streamer.from(ext.channelId(), ext.channelName(), ext.channelImageUrl()));
+                }
+            }
+
+            if (!toSave.isEmpty()) {
+                streamerRepository.saveAll(toSave);
+            }
+        }
+    }
+
+    private <T> List<List<T>> partitionList(List<T> list, int size) {
+        List<List<T>> partitions = new ArrayList<>();
+        for (int i = 0; i < list.size(); i += size) {
+            partitions.add(new ArrayList<>(list.subList(i, Math.min(list.size(), i + size))));
+        }
+        return partitions;
+    }
+
+}

--- a/api/src/main/java/team/pickz/api/domain/streamer/application/StreamerSyncService.java
+++ b/api/src/main/java/team/pickz/api/domain/streamer/application/StreamerSyncService.java
@@ -23,6 +23,9 @@ public class StreamerSyncService {
 
     @Transactional
     public void syncStreamers(List<String> targetChannelIds) {
+        if(targetChannelIds == null || targetChannelIds.isEmpty()) {
+            return;
+        }
         List<List<String>> partitionedIds = partitionList(targetChannelIds, CHUNK_SIZE);
 
         for(List<String> chunk : partitionedIds) {
@@ -36,7 +39,7 @@ public class StreamerSyncService {
             for (ChzzkChannelResponse ext : externalChannels) {
                 Streamer existing = existingMap.get(ext.channelId());
                 if (existing != null) {
-                    existing.updateProfile(ext.channelName(), ext.channelName(), ext.channelImageUrl());
+                    existing.updateProfile(ext.channelId(), ext.channelName(), ext.channelImageUrl());
                 } else {
                     toSave.add(Streamer.from(ext.channelId(), ext.channelName(), ext.channelImageUrl()));
                 }

--- a/api/src/main/java/team/pickz/api/domain/streamer/application/dto/StreamerSearchResponse.java
+++ b/api/src/main/java/team/pickz/api/domain/streamer/application/dto/StreamerSearchResponse.java
@@ -1,0 +1,26 @@
+package team.pickz.api.domain.streamer.application.dto;
+
+import team.pickz.api.domain.streamer.domain.Streamer;
+
+public record StreamerSearchResponse(
+
+        Long id,
+
+        String channelId,
+
+        String channelName,
+
+        String profileImageUrl
+
+) {
+
+    public static StreamerSearchResponse from(Streamer streamer) {
+        return new StreamerSearchResponse(
+                streamer.getId(),
+                streamer.getChannelId(),
+                streamer.getChannelName(),
+                streamer.getProfileImageUrl()
+        );
+    }
+
+}

--- a/api/src/main/java/team/pickz/api/domain/streamer/domain/Streamer.java
+++ b/api/src/main/java/team/pickz/api/domain/streamer/domain/Streamer.java
@@ -1,0 +1,39 @@
+package team.pickz.api.domain.streamer.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Streamer {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String channelId;
+
+    private String channelName;
+
+    private String profileImageUrl;
+
+
+    public void updateProfile(String channelId, String channelName, String profileImageUrl) {
+        this.channelId = channelId;
+        this.channelName = channelName;
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    public static Streamer from(String channelId, String channelName,String profileImageUrl) {
+        return Streamer.builder()
+                .channelId(channelId)
+                .channelName(channelName)
+                .profileImageUrl(profileImageUrl)
+                .build();
+    }
+
+}

--- a/api/src/main/java/team/pickz/api/domain/streamer/domain/StreamerRepository.java
+++ b/api/src/main/java/team/pickz/api/domain/streamer/domain/StreamerRepository.java
@@ -1,0 +1,16 @@
+package team.pickz.api.domain.streamer.domain;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface StreamerRepository {
+
+    void saveAll(List<Streamer> streamers);
+
+    List<Streamer> findByChannelIdIn(List<String> channelIds);
+
+    Page<Streamer> findByChannelNameContainingIgnoreCase(String keyword, Pageable pageable);
+
+}

--- a/api/src/main/java/team/pickz/api/domain/streamer/domain/StreamerRepository.java
+++ b/api/src/main/java/team/pickz/api/domain/streamer/domain/StreamerRepository.java
@@ -1,8 +1,5 @@
 package team.pickz.api.domain.streamer.domain;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-
 import java.util.List;
 
 public interface StreamerRepository {
@@ -11,6 +8,6 @@ public interface StreamerRepository {
 
     List<Streamer> findByChannelIdIn(List<String> channelIds);
 
-    Page<Streamer> findByChannelNameContainingIgnoreCase(String keyword, Pageable pageable);
+    List<Streamer> findTop20ByChannelNameContainingIgnoreCaseOrderByChannelNameAsc(String keyword);
 
 }

--- a/api/src/main/java/team/pickz/api/domain/streamer/infrastructure/StreamerJpaRepository.java
+++ b/api/src/main/java/team/pickz/api/domain/streamer/infrastructure/StreamerJpaRepository.java
@@ -1,0 +1,16 @@
+package team.pickz.api.domain.streamer.infrastructure;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.pickz.api.domain.streamer.domain.Streamer;
+
+import java.util.List;
+
+public interface StreamerJpaRepository extends JpaRepository<Streamer, Long> {
+
+    List<Streamer> findByChannelIdIn(List<String> channelIds);
+
+    Page<Streamer> findByChannelNameContainingIgnoreCase(String keyword, Pageable pageable);
+
+}

--- a/api/src/main/java/team/pickz/api/domain/streamer/infrastructure/StreamerJpaRepository.java
+++ b/api/src/main/java/team/pickz/api/domain/streamer/infrastructure/StreamerJpaRepository.java
@@ -1,7 +1,5 @@
 package team.pickz.api.domain.streamer.infrastructure;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import team.pickz.api.domain.streamer.domain.Streamer;
 
@@ -11,6 +9,6 @@ public interface StreamerJpaRepository extends JpaRepository<Streamer, Long> {
 
     List<Streamer> findByChannelIdIn(List<String> channelIds);
 
-    Page<Streamer> findByChannelNameContainingIgnoreCase(String keyword, Pageable pageable);
+    List<Streamer> findTop20ByChannelNameContainingIgnoreCaseOrderByChannelNameAsc(String keyword);
 
 }

--- a/api/src/main/java/team/pickz/api/domain/streamer/infrastructure/StreamerRepositoryImpl.java
+++ b/api/src/main/java/team/pickz/api/domain/streamer/infrastructure/StreamerRepositoryImpl.java
@@ -1,8 +1,6 @@
 package team.pickz.api.domain.streamer.infrastructure;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import team.pickz.api.domain.streamer.domain.Streamer;
 import team.pickz.api.domain.streamer.domain.StreamerRepository;
@@ -26,8 +24,8 @@ public class StreamerRepositoryImpl implements StreamerRepository {
     }
 
     @Override
-    public Page<Streamer> findByChannelNameContainingIgnoreCase(String keyword, Pageable pageable) {
-        return streamerJpaRepository.findByChannelNameContainingIgnoreCase(keyword, pageable);
+    public List<Streamer> findTop20ByChannelNameContainingIgnoreCaseOrderByChannelNameAsc(String keyword) {
+        return streamerJpaRepository.findTop20ByChannelNameContainingIgnoreCaseOrderByChannelNameAsc(keyword);
     }
 
 }

--- a/api/src/main/java/team/pickz/api/domain/streamer/infrastructure/StreamerRepositoryImpl.java
+++ b/api/src/main/java/team/pickz/api/domain/streamer/infrastructure/StreamerRepositoryImpl.java
@@ -1,0 +1,33 @@
+package team.pickz.api.domain.streamer.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import team.pickz.api.domain.streamer.domain.Streamer;
+import team.pickz.api.domain.streamer.domain.StreamerRepository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class StreamerRepositoryImpl implements StreamerRepository {
+
+    private final StreamerJpaRepository streamerJpaRepository;
+
+    @Override
+    public void saveAll(List<Streamer> streamers) {
+        streamerJpaRepository.saveAll(streamers);
+    }
+
+    @Override
+    public List<Streamer> findByChannelIdIn(List<String> channelIds) {
+        return streamerJpaRepository.findByChannelIdIn(channelIds);
+    }
+
+    @Override
+    public Page<Streamer> findByChannelNameContainingIgnoreCase(String keyword, Pageable pageable) {
+        return streamerJpaRepository.findByChannelNameContainingIgnoreCase(keyword, pageable);
+    }
+
+}

--- a/api/src/main/java/team/pickz/api/domain/streamer/presentation/AdminStreamerController.java
+++ b/api/src/main/java/team/pickz/api/domain/streamer/presentation/AdminStreamerController.java
@@ -1,0 +1,23 @@
+package team.pickz.api.domain.streamer.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import team.pickz.api.domain.streamer.application.StreamerSyncService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/admin/streamers")
+@RequiredArgsConstructor
+public class AdminStreamerController {
+
+    private final StreamerSyncService streamerSyncService;
+
+    @PostMapping("/sync")
+    public ResponseEntity<Void> manualSyncTargetStreamers(@RequestBody List<String> channelIds) {
+        streamerSyncService.syncStreamers(channelIds);
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/api/src/main/java/team/pickz/api/domain/streamer/presentation/StreamerController.java
+++ b/api/src/main/java/team/pickz/api/domain/streamer/presentation/StreamerController.java
@@ -1,0 +1,31 @@
+package team.pickz.api.domain.streamer.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import team.pickz.api.domain.streamer.application.StreamerSearchService;
+import team.pickz.api.domain.streamer.application.dto.StreamerSearchResponse;
+
+@RestController
+@RequestMapping("/streamers")
+@RequiredArgsConstructor
+public class StreamerController {
+
+    private final StreamerSearchService streamerSearchService;
+
+    @GetMapping("/search")
+    public ResponseEntity<Page<StreamerSearchResponse>> searchStreamers(
+            @RequestParam(name = "keyword") String keyword,
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "10") int size
+    ) {
+        Page<StreamerSearchResponse> result = streamerSearchService.searchByKeyword(keyword, page, size);
+
+        return ResponseEntity.status(200).body(result);
+    }
+
+}

--- a/api/src/main/java/team/pickz/api/domain/streamer/presentation/StreamerController.java
+++ b/api/src/main/java/team/pickz/api/domain/streamer/presentation/StreamerController.java
@@ -1,7 +1,6 @@
 package team.pickz.api.domain.streamer.presentation;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -10,20 +9,20 @@ import org.springframework.web.bind.annotation.RestController;
 import team.pickz.api.domain.streamer.application.StreamerSearchService;
 import team.pickz.api.domain.streamer.application.dto.StreamerSearchResponse;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/streamers")
 @RequiredArgsConstructor
-public class StreamerController {
+public class StreamerController implements StreamerDocsController{
 
     private final StreamerSearchService streamerSearchService;
 
     @GetMapping("/search")
-    public ResponseEntity<Page<StreamerSearchResponse>> searchStreamers(
-            @RequestParam(name = "keyword") String keyword,
-            @RequestParam(name = "page", defaultValue = "0") int page,
-            @RequestParam(name = "size", defaultValue = "10") int size
+    public ResponseEntity<List<StreamerSearchResponse>> searchStreamers(
+            @RequestParam(name = "keyword") String keyword
     ) {
-        Page<StreamerSearchResponse> result = streamerSearchService.searchByKeyword(keyword, page, size);
+        List<StreamerSearchResponse> result = streamerSearchService.searchByKeyword(keyword);
 
         return ResponseEntity.status(200).body(result);
     }

--- a/api/src/main/java/team/pickz/api/domain/streamer/presentation/StreamerDocsController.java
+++ b/api/src/main/java/team/pickz/api/domain/streamer/presentation/StreamerDocsController.java
@@ -1,0 +1,31 @@
+package team.pickz.api.domain.streamer.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import team.pickz.api.domain.streamer.application.dto.StreamerSearchResponse;
+
+import java.util.List;
+
+@Tag(name = "Streamer", description = "스트리머 관련 API")
+@RequestMapping("/streamers")
+public interface StreamerDocsController {
+
+    @Operation(
+            summary = "스트리머 검색",
+            description = "채널명으로 스트리머를 검색합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+    })
+    @GetMapping("/search")
+    ResponseEntity<List<StreamerSearchResponse>> searchStreamers(
+            @RequestParam(name = "keyword") String keyword
+    );
+
+}

--- a/api/src/main/java/team/pickz/api/global/config/SecurityConfig.java
+++ b/api/src/main/java/team/pickz/api/global/config/SecurityConfig.java
@@ -32,7 +32,8 @@ public class SecurityConfig {
 
     private static final String[] PERMIT_ALL_PATTERNS = {
             "/", "/oauth2/**", "/auths/token","/actuator/**",
-            "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html"
+            "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html",
+            "/admin/**"
     };
     private static final List<String> ALLOWED_METHODS = List.of("GET", "POST", "PATCH", "PUT", "DELETE");
     private static final List<String> ALLOWED_HEADERS = List.of("*");

--- a/api/src/main/java/team/pickz/api/infra/chzzk/client/ChzzkClient.java
+++ b/api/src/main/java/team/pickz/api/infra/chzzk/client/ChzzkClient.java
@@ -20,14 +20,15 @@ public class ChzzkClient {
     public List<ChzzkChannelResponse> getChannels(List<String> channelIds) {
         String channelIdsParam = String.join(",", channelIds);
 
-        return restClient.get()
+        ChzzkChannelResponseList response = restClient.get()
                 .uri(uriBuilder -> uriBuilder
                         .path("/open/v1/channels")
                         .queryParam("channelIds", channelIdsParam)
                         .build())
                 .retrieve()
-                .body(ChzzkChannelResponseList.class)
-                .getData();
+                .body(ChzzkChannelResponseList.class);
+
+        return response != null ? response.getData() : List.of();
     }
 
 }

--- a/api/src/main/java/team/pickz/api/infra/chzzk/client/ChzzkClient.java
+++ b/api/src/main/java/team/pickz/api/infra/chzzk/client/ChzzkClient.java
@@ -1,0 +1,33 @@
+package team.pickz.api.infra.chzzk.client;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import team.pickz.api.infra.chzzk.dto.ChzzkChannelResponseList;
+import team.pickz.api.infra.chzzk.dto.ChzzkChannelResponse;
+
+import java.util.List;
+
+@Component
+public class ChzzkClient {
+
+    private final RestClient restClient;
+
+    public ChzzkClient(@Qualifier("chzzkRestClient") RestClient restClient) {
+        this.restClient = restClient;
+    }
+
+    public List<ChzzkChannelResponse> getChannels(List<String> channelIds) {
+        String channelIdsParam = String.join(",", channelIds);
+
+        return restClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/open/v1/channels")
+                        .queryParam("channelIds", channelIdsParam)
+                        .build())
+                .retrieve()
+                .body(ChzzkChannelResponseList.class)
+                .getData();
+    }
+
+}

--- a/api/src/main/java/team/pickz/api/infra/chzzk/config/ChzzkProperties.java
+++ b/api/src/main/java/team/pickz/api/infra/chzzk/config/ChzzkProperties.java
@@ -1,0 +1,15 @@
+package team.pickz.api.infra.chzzk.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "chzzk.api")
+public record ChzzkProperties(
+
+        String baseUrl,
+
+        String clientId,
+
+        String clientSecret
+
+) {
+}

--- a/api/src/main/java/team/pickz/api/infra/chzzk/config/ChzzkRestClientConfig.java
+++ b/api/src/main/java/team/pickz/api/infra/chzzk/config/ChzzkRestClientConfig.java
@@ -1,0 +1,26 @@
+package team.pickz.api.infra.chzzk.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+@RequiredArgsConstructor
+public class ChzzkRestClientConfig {
+
+    private final ChzzkProperties chzzkProperties;
+
+    @Bean(name = "chzzkRestClient")
+    public RestClient chzzkRestClient() {
+        return RestClient.builder()
+                .baseUrl(chzzkProperties.baseUrl())
+                .defaultHeader("Client-Id", chzzkProperties.clientId())
+                .defaultHeader("Client-Secret", chzzkProperties.clientSecret())
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+
+}

--- a/api/src/main/java/team/pickz/api/infra/chzzk/dto/ChzzkChannelResponse.java
+++ b/api/src/main/java/team/pickz/api/infra/chzzk/dto/ChzzkChannelResponse.java
@@ -1,0 +1,15 @@
+package team.pickz.api.infra.chzzk.dto;
+
+import lombok.Builder;
+
+@Builder
+public record ChzzkChannelResponse(
+
+        String channelId,
+
+        String channelName,
+
+        String channelImageUrl
+
+) {
+}

--- a/api/src/main/java/team/pickz/api/infra/chzzk/dto/ChzzkChannelResponseList.java
+++ b/api/src/main/java/team/pickz/api/infra/chzzk/dto/ChzzkChannelResponseList.java
@@ -1,0 +1,26 @@
+package team.pickz.api.infra.chzzk.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ChzzkChannelResponseList(
+
+        int code,
+
+        String message,
+
+        Content content
+
+) {
+
+    public record Content(
+            List<ChzzkChannelResponse> data
+    ) {}
+
+    public List<ChzzkChannelResponse> getData() {
+        return content != null && content.data != null ? content.data : List.of();
+    }
+
+}


### PR DESCRIPTION
## 관련 이슈

- Closes #5 

## 작업 내용

> 이번 PR에서 작업한 내용을 작성해주세요.

- 치지직 API 연동
- 스트리머 검색 기능 구현
- 스트리머 정보 DB에 저장하는 기능 구현 (관리자)

## 특이사항

> 후속 작업, 영향 범위, 주의사항이 있으면 작성해주세요.

-

## 추가 정보

> UI 변경, 요청/응답 예시, 스크린샷 등이 있다면 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 스트리머 검색 기능 추가 — 채널명으로 검색해 최대 20건 반환
  * 관리자용 스트리머 수동 동기화 기능 추가 — 채널 ID 목록으로 외부 소스와 일괄 동기화

* **통합**
  * 외부 스트리머 데이터 API 연동 및 관련 설정 추가

* **문서**
  * 스트리머 검색 API에 대한 OpenAPI/Swagger 문서화 추가

* **기타**
  * 관리자 경로 접근 규칙에 대한 보안 설정 변경사항 적용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->