### PR TITLE
[api] chore: 스트리머 검색 엔드포인트 security 허용 URL에 추가

### DIFF
--- a/api/src/main/java/team/pickz/api/global/config/SecurityConfig.java
+++ b/api/src/main/java/team/pickz/api/global/config/SecurityConfig.java
@@ -33,7 +33,7 @@ public class SecurityConfig {
     private static final String[] PERMIT_ALL_PATTERNS = {
             "/", "/oauth2/**", "/auths/token","/actuator/**",
             "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html",
-            "/admin/**"
+            "/admin/**", "/streamers/**"
     };
     private static final List<String> ALLOWED_METHODS = List.of("GET", "POST", "PATCH", "PUT", "DELETE");
     private static final List<String> ALLOWED_HEADERS = List.of("*");


### PR DESCRIPTION
## 관련 이슈

- Closes #22 

## 작업 내용

> 이번 PR에서 작업한 내용을 작성해주세요.

- 인증 없이 스트리머 검색할 수 있도록 Spring Security 허용 URL에 추가



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **구성 변경**
  * 스트리머 관련 엔드포인트가 인증 없이 공개적으로 접근 가능하도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->