### PR TITLE
[web] feat: 드래프트 웹소켓 통합 테스트 페이지 추가

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -13,6 +13,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@stomp/stompjs": "^7.3.0",
     "@tanstack/react-query": "^5.90.21",
     "clsx": "^2.1.1",
     "motion": "^12.38.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@stomp/stompjs':
+        specifier: ^7.3.0
+        version: 7.3.0
       '@tanstack/react-query':
         specifier: ^5.90.21
         version: 5.97.0(react@19.2.3)
@@ -460,6 +463,9 @@ packages:
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@stomp/stompjs@7.3.0':
+    resolution: {integrity: sha512-nKMLoFfJhrQAqkvvKd1vLq/cVBGCMwPRCD0LqW7UT1fecRx9C3GoKEIR2CYwVuErGeZu8w0kFkl2rlhPlqHVgQ==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -2584,6 +2590,8 @@ snapshots:
   '@nolyfill/is-core-module@1.0.39': {}
 
   '@rtsao/scc@1.1.0': {}
+
+  '@stomp/stompjs@7.3.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:

--- a/web/src/apis/drafts/draft-room.api.ts
+++ b/web/src/apis/drafts/draft-room.api.ts
@@ -1,0 +1,203 @@
+import type {
+  CreateDraftRoomRequest,
+  CreateDraftRoomResponse,
+  JoinDraftRoomResponse,
+  StartDraftRoomParams,
+} from "@/types";
+
+const defaultCreateDraftRoomRequest: CreateDraftRoomRequest = {
+  mode: "TOGETHER",
+  ruleName: "SNAKE",
+};
+
+function getApiBaseUrl() {
+  const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL?.trim() ?? "";
+
+  if (apiBaseUrl.length === 0) {
+    throw new Error("NEXT_PUBLIC_API_BASE_URL 환경 변수가 없습니다.");
+  }
+
+  return apiBaseUrl;
+}
+
+function createApiUrl(pathname: string) {
+  const normalizedBaseUrl = getApiBaseUrl().replace(/\/+$/, "");
+  const normalizedPathname = pathname.replace(/^\/+/, "");
+
+  return new URL(`${normalizedBaseUrl}/${normalizedPathname}`);
+}
+
+async function readResponsePayload(response: Response) {
+  const contentType = response.headers.get("content-type") ?? "";
+
+  if (contentType.includes("application/json")) {
+    try {
+      return await response.json();
+    } catch {
+      return null;
+    }
+  }
+
+  const text = await response.text();
+
+  return text.length > 0 ? text : null;
+}
+
+function getApiErrorMessage(payload: unknown, fallbackMessage: string) {
+  if (payload && typeof payload === "object" && "message" in payload) {
+    const message = payload.message;
+
+    if (typeof message === "string" && message.length > 0) {
+      return message;
+    }
+  }
+
+  if (typeof payload === "string" && payload.length > 0) {
+    return payload;
+  }
+
+  return fallbackMessage;
+}
+
+function createApiError(response: Response, payload: unknown, fallbackMessage: string) {
+  const message = getApiErrorMessage(payload, fallbackMessage);
+
+  return new Error(`${message} (HTTP ${response.status})`);
+}
+
+function normalizeNicknameValue(value: unknown) {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmedValue = value.trim();
+
+  if (trimmedValue.length === 0 || trimmedValue === "null") {
+    return undefined;
+  }
+
+  return trimmedValue;
+}
+
+function readNicknameFromPayload(payload: Record<string, unknown>) {
+  return (
+    normalizeNicknameValue(payload.nickname) ??
+    normalizeNicknameValue(payload.nickName)
+  );
+}
+
+function isCreateDraftRoomResponse(payload: unknown): payload is CreateDraftRoomResponse {
+  if (!payload || typeof payload !== "object") {
+    return false;
+  }
+
+  const recordPayload = payload as Record<string, unknown>;
+
+  return (
+    typeof recordPayload.roomId === "number" &&
+    typeof recordPayload.inviteCode === "string" &&
+    typeof recordPayload.participantToken === "string"
+  );
+}
+
+function isJoinDraftRoomResponse(payload: unknown): payload is JoinDraftRoomResponse {
+  if (!payload || typeof payload !== "object") {
+    return false;
+  }
+
+  const recordPayload = payload as Record<string, unknown>;
+
+  return typeof recordPayload.participantToken === "string";
+}
+
+function normalizeCreateDraftRoomResponse(payload: CreateDraftRoomResponse) {
+  const recordPayload = payload as unknown as Record<string, unknown>;
+
+  return {
+    ...payload,
+    nickname: readNicknameFromPayload(recordPayload),
+  };
+}
+
+function normalizeJoinDraftRoomResponse(payload: JoinDraftRoomResponse) {
+  const recordPayload = payload as unknown as Record<string, unknown>;
+
+  return {
+    ...payload,
+    nickname: readNicknameFromPayload(recordPayload),
+  };
+}
+
+export async function createDraftRoom(
+  request: CreateDraftRoomRequest = defaultCreateDraftRoomRequest,
+) {
+  const response = await fetch(createApiUrl("drafts/rooms"), {
+    method: "POST",
+    cache: "no-store",
+    credentials: "include",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(request),
+  });
+  const payload = await readResponsePayload(response);
+
+  if (!response.ok) {
+    throw createApiError(response, payload, "드래프트 방 생성 API 호출에 실패했습니다.");
+  }
+
+  if (!isCreateDraftRoomResponse(payload)) {
+    throw new Error("드래프트 방 생성 응답 형식이 올바르지 않습니다.");
+  }
+
+  return normalizeCreateDraftRoomResponse(payload);
+}
+
+export async function joinDraftRoomByInviteCode(inviteCode: string) {
+  const response = await fetch(
+    createApiUrl(`drafts/rooms/invites/${encodeURIComponent(inviteCode)}/participants`),
+    {
+      method: "POST",
+      cache: "no-store",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+      },
+    },
+  );
+  const payload = await readResponsePayload(response);
+
+  if (!response.ok) {
+    throw createApiError(response, payload, "드래프트 방 참여 API 호출에 실패했습니다.");
+  }
+
+  if (!isJoinDraftRoomResponse(payload)) {
+    throw new Error("드래프트 방 참여 응답 형식이 올바르지 않습니다.");
+  }
+
+  return normalizeJoinDraftRoomResponse(payload);
+}
+
+export async function startDraftRoom({
+  participantToken,
+  request,
+  roomId,
+}: StartDraftRoomParams) {
+  const response = await fetch(createApiUrl(`drafts/rooms/${roomId}/settings`), {
+    method: "PATCH",
+    cache: "no-store",
+    credentials: "include",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      "X-Participant-Token": participantToken,
+    },
+    body: JSON.stringify(request),
+  });
+  const payload = await readResponsePayload(response);
+
+  if (!response.ok) {
+    throw createApiError(response, payload, "드래프트 방 설정 및 시작 API 호출에 실패했습니다.");
+  }
+}

--- a/web/src/apis/drafts/index.ts
+++ b/web/src/apis/drafts/index.ts
@@ -1,0 +1,1 @@
+export { createDraftRoom, joinDraftRoomByInviteCode, startDraftRoom } from "./draft-room.api";

--- a/web/src/app/(main)/draft/api-test/page.tsx
+++ b/web/src/app/(main)/draft/api-test/page.tsx
@@ -1,0 +1,619 @@
+"use client";
+
+import { useMutation, useQuery } from "@tanstack/react-query";
+import Link from "next/link";
+import { cn } from "@/utils";
+import { z } from "zod";
+import { useMemo, useState } from "react";
+
+function SearchIcon() {
+  return (
+    <svg viewBox="0 0 20 20" fill="none" className="size-4" aria-hidden="true">
+      <circle cx="8.5" cy="8.5" r="5.5" stroke="currentColor" strokeWidth="1.8" />
+      <path d="m13 13 4 4" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function ArrowLeftIcon() {
+  return (
+    <svg viewBox="0 0 20 20" fill="none" className="size-4" aria-hidden="true">
+      <path d="M15 10H5" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+      <path
+        d="m9 6-4 4 4 4"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function RefreshIcon() {
+  return (
+    <svg viewBox="0 0 20 20" fill="none" className="size-4" aria-hidden="true">
+      <path
+        d="M16.5 10a6.5 6.5 0 1 1-1.9-4.6"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+      />
+      <path
+        d="M12.5 3.5h3.7v3.7"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+const streamerSearchItemSchema = z.object({
+  id: z.number().int().nonnegative(),
+  channelId: z.string().min(1),
+  channelName: z.string().min(1),
+  profileImageUrl: z.string().min(1),
+});
+
+const streamerSearchResponseSchema = z.array(streamerSearchItemSchema);
+
+type StreamerSearchItem = z.infer<typeof streamerSearchItemSchema>;
+
+function getApiBaseUrlConfigurationError(value: string) {
+  if (value.length === 0) {
+    return "NEXT_PUBLIC_API_BASE_URL 환경 변수가 없습니다.";
+  }
+
+  try {
+    new URL(value);
+
+    return null;
+  } catch {
+    return "NEXT_PUBLIC_API_BASE_URL 값이 올바른 URL 형식이 아닙니다.";
+  }
+}
+
+function createApiUrl(baseUrl: string, pathname: string) {
+  return new URL(pathname.replace(/^\/+/, ""), `${baseUrl.replace(/\/+$/, "")}/`);
+}
+
+function createStreamerSearchUrl(baseUrl: string, keyword: string) {
+  const url = createApiUrl(baseUrl, "streamers/search");
+  url.searchParams.set("keyword", keyword);
+
+  return url;
+}
+
+function createLoginUrl(baseUrl: string) {
+  return createApiUrl(baseUrl, "auths/login");
+}
+
+function createLogoutUrl(baseUrl: string) {
+  return createApiUrl(baseUrl, "auths/logout");
+}
+
+async function readResponsePayload(response: Response) {
+  const contentType = response.headers.get("content-type") ?? "";
+
+  if (contentType.includes("application/json")) {
+    try {
+      return await response.json();
+    } catch {
+      return null;
+    }
+  }
+
+  try {
+    const text = await response.text();
+
+    return text.length > 0 ? text : null;
+  } catch {
+    return null;
+  }
+}
+
+function getApiErrorMessage(payload: unknown, fallbackMessage: string) {
+  if (payload && typeof payload === "object" && "message" in payload && typeof payload.message === "string") {
+    return payload.message;
+  }
+
+  return fallbackMessage;
+}
+
+function getApiErrorDetail(payload: unknown) {
+  if (payload && typeof payload === "object" && "detail" in payload && typeof payload.detail === "string") {
+    return payload.detail;
+  }
+
+  if (typeof payload === "string") {
+    return payload;
+  }
+
+  return "";
+}
+
+async function fetchStreamerSearchResults(baseUrl: string, keyword: string) {
+  if (baseUrl.length === 0) {
+    throw new Error("NEXT_PUBLIC_API_BASE_URL 환경 변수가 없습니다.");
+  }
+
+  let response: Response;
+
+  try {
+    response = await fetch(createStreamerSearchUrl(baseUrl, keyword).toString(), {
+      cache: "no-store",
+      headers: {
+        Accept: "application/json",
+      },
+    });
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : "알 수 없는 오류";
+
+    throw new Error(`브라우저에서 API 직접 호출에 실패했습니다. ${detail}`);
+  }
+
+  let payload: unknown = null;
+
+  payload = await readResponsePayload(response);
+
+  if (!response.ok) {
+    const message = getApiErrorMessage(payload, "스트리머 검색 API 호출에 실패했습니다.");
+    const detail = getApiErrorDetail(payload);
+
+    throw new Error(detail ? `${message} ${detail}` : message);
+  }
+
+  return streamerSearchResponseSchema.parse(payload);
+}
+
+async function logout(baseUrl: string) {
+  if (baseUrl.length === 0) {
+    throw new Error("NEXT_PUBLIC_API_BASE_URL 환경 변수가 없습니다.");
+  }
+
+  let response: Response;
+
+  try {
+    response = await fetch(createLogoutUrl(baseUrl).toString(), {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+      },
+    });
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : "알 수 없는 오류";
+
+    throw new Error(`브라우저에서 로그아웃 API 직접 호출에 실패했습니다. ${detail}`);
+  }
+
+  const payload = await readResponsePayload(response);
+
+  if (!response.ok) {
+    const message = getApiErrorMessage(payload, "로그아웃 API 호출에 실패했습니다.");
+    const detail = getApiErrorDetail(payload);
+
+    throw new Error(detail ? `${message} ${detail}` : message);
+  }
+
+  return {
+    payload,
+    status: response.status,
+  };
+}
+
+function StatusChip({ label, tone }: { label: string; tone: "default" | "error" | "success" }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold",
+        tone === "success"
+          ? "bg-emerald-100 text-emerald-700"
+          : tone === "error"
+            ? "bg-rose-100 text-rose-700"
+            : "bg-surface-muted text-text-secondary",
+      )}
+    >
+      {label}
+    </span>
+  );
+}
+
+function ResultCard({ streamer }: { streamer: StreamerSearchItem }) {
+  return (
+    <article className="flex items-center gap-4 rounded-3xl border border-border bg-surface px-4 py-4">
+      <div className="flex size-14 shrink-0 items-center justify-center overflow-hidden rounded-full bg-surface-muted">
+        {/* API 테스트 화면이라 upstream 이미지 URL 원본을 그대로 확인합니다. */}
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={streamer.profileImageUrl}
+          alt={streamer.channelName}
+          className="size-full object-cover"
+          referrerPolicy="no-referrer"
+        />
+      </div>
+
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <h3 className="truncate text-base font-semibold text-text-primary">{streamer.channelName}</h3>
+          <StatusChip label={`id ${streamer.id}`} tone="default" />
+        </div>
+        <p className="mt-1 text-sm text-text-secondary">@{streamer.channelId}</p>
+        <p className="mt-2 truncate text-xs text-text-muted">{streamer.profileImageUrl}</p>
+      </div>
+    </article>
+  );
+}
+
+export default function DraftApiTestPage() {
+  const [keyword, setKeyword] = useState("");
+  const [submittedKeyword, setSubmittedKeyword] = useState("");
+  const [lastLogoutRequestedAt, setLastLogoutRequestedAt] = useState<number | null>(null);
+  const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL?.trim() ?? "";
+  const configurationError = getApiBaseUrlConfigurationError(apiBaseUrl);
+  const loginUrl = configurationError ? "" : createLoginUrl(apiBaseUrl).toString();
+  const logoutUrl = configurationError ? "" : createLogoutUrl(apiBaseUrl).toString();
+
+  const searchQuery = useQuery({
+    queryKey: ["streamer-api-test", apiBaseUrl, submittedKeyword],
+    enabled: submittedKeyword.length > 0 && !configurationError,
+    queryFn: () => fetchStreamerSearchResults(apiBaseUrl, submittedKeyword),
+  });
+  const logoutMutation = useMutation({
+    mutationKey: ["auth-logout", apiBaseUrl],
+    mutationFn: () => logout(apiBaseUrl),
+  });
+
+  const requestUrl = useMemo(() => {
+    if (configurationError) {
+      return configurationError;
+    }
+
+    if (submittedKeyword.length === 0) {
+      return `${apiBaseUrl.replace(/\/+$/, "")}/streamers/search?keyword=...`;
+    }
+
+    const url = createStreamerSearchUrl(apiBaseUrl, submittedKeyword);
+
+    return url.toString();
+  }, [apiBaseUrl, configurationError, submittedKeyword]);
+
+  const hasResults = (searchQuery.data?.length ?? 0) > 0;
+  const lastSearchUpdated =
+    searchQuery.dataUpdatedAt > 0
+      ? new Date(searchQuery.dataUpdatedAt).toLocaleTimeString("ko-KR", { hour12: false })
+      : null;
+  const lastLogoutUpdated =
+    lastLogoutRequestedAt
+      ? new Date(lastLogoutRequestedAt).toLocaleTimeString("ko-KR", { hour12: false })
+      : null;
+  const logoutResponsePreview = useMemo(() => {
+    if (!logoutMutation.isSuccess) {
+      return "로그아웃 호출 결과가 여기에 표시됩니다.";
+    }
+
+    if (logoutMutation.data.payload === null) {
+      return "응답 본문 없음";
+    }
+
+    return JSON.stringify(logoutMutation.data.payload, null, 2);
+  }, [logoutMutation.data, logoutMutation.isSuccess]);
+
+  return (
+    <main className="min-h-[calc(100dvh-var(--header-height))] bg-background px-6 py-6 xl:px-8">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-5">
+        <section className="rounded-[28px] border border-border bg-surface p-6 shadow-sm">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+            <div>
+              <Link
+                href="/draft"
+                className="inline-flex items-center gap-2 rounded-full border border-border bg-surface-muted px-3 py-2 text-xs font-semibold text-text-secondary transition-colors hover:text-text-primary"
+              >
+                <ArrowLeftIcon />
+                드래프트로 돌아가기
+              </Link>
+
+              <p className="mt-4 text-xs font-bold tracking-[0.16em] text-violet-600 uppercase">
+                API TEST
+              </p>
+              <h1 className="mt-2 text-3xl font-bold tracking-[-0.03em] text-text-primary">API 연동 확인</h1>
+              <p className="mt-2 max-w-3xl text-sm leading-6 text-text-secondary">
+                인증과 스트리머 검색을 브라우저에서 `NEXT_PUBLIC_API_BASE_URL` 기준으로 직접 테스트합니다.
+              </p>
+            </div>
+
+            <div className="grid gap-3 rounded-3xl border border-border bg-surface-muted px-4 py-4 text-sm lg:min-w-[320px]">
+              <div>
+                <p className="text-xs font-semibold text-text-muted">Target Server</p>
+                <p className="mt-1 break-all font-semibold text-text-primary">
+                  {configurationError ? "미설정" : apiBaseUrl}
+                </p>
+              </div>
+              <div>
+                <p className="text-xs font-semibold text-text-muted">Upstream Endpoint</p>
+                <p className="mt-1 break-all font-medium text-text-secondary">GET /streamers/search</p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="rounded-[28px] border border-border bg-surface p-6 shadow-sm">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <h2 className="text-xl font-bold text-text-primary">Auth API Test</h2>
+              <p className="mt-1 text-sm text-text-secondary">
+                로그인은 브라우저를 네이버 인증 페이지로 이동시키고, 로그아웃은 현재 브라우저 쿠키로 직접 호출합니다.
+              </p>
+            </div>
+          </div>
+
+          <div className="mt-4 grid gap-5 xl:grid-cols-2">
+            <article className="rounded-3xl border border-border bg-surface-muted px-5 py-5">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <p className="text-sm font-semibold text-text-primary">GET /auths/login</p>
+                  <p className="mt-1 text-sm leading-6 text-text-secondary">
+                    버튼을 누르면 네이버 로그인 인증 화면으로 이동합니다. 성공 후에는 백엔드에 설정된 redirect URL로 이동합니다.
+                  </p>
+                </div>
+                <StatusChip label="redirect" tone="default" />
+              </div>
+
+              <div className="mt-4 rounded-3xl border border-border bg-surface px-4 py-4">
+                <p className="text-xs font-semibold text-text-muted">Request URL</p>
+                <p className="mt-1 break-all text-sm text-text-secondary">
+                  {configurationError ? configurationError : loginUrl}
+                </p>
+              </div>
+
+              <button
+                type="button"
+                disabled={Boolean(configurationError)}
+                onClick={() => {
+                  if (configurationError) {
+                    return;
+                  }
+
+                  window.location.assign(loginUrl);
+                }}
+                className="mt-4 flex h-12 w-full cursor-pointer items-center justify-center rounded-2xl bg-slate-950 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                네이버 로그인 이동
+              </button>
+            </article>
+
+            <article className="rounded-3xl border border-border bg-surface-muted px-5 py-5">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <p className="text-sm font-semibold text-text-primary">POST /auths/logout</p>
+                  <p className="mt-1 text-sm leading-6 text-text-secondary">
+                    현재 브라우저에 저장된 `pickz.co.kr` 인증 쿠키를 포함해 로그아웃을 직접 호출합니다.
+                  </p>
+                </div>
+              </div>
+
+              <div className="mt-4 flex flex-wrap items-center gap-2">
+                <StatusChip
+                  label={
+                    logoutMutation.isError
+                      ? "호출 실패"
+                      : logoutMutation.isPending
+                        ? "호출 중"
+                        : logoutMutation.isSuccess
+                          ? "호출 성공"
+                          : "대기 중"
+                  }
+                  tone={
+                    logoutMutation.isError
+                      ? "error"
+                      : logoutMutation.isSuccess
+                        ? "success"
+                        : "default"
+                  }
+                />
+                {logoutMutation.isSuccess ? (
+                  <StatusChip label={`status ${logoutMutation.data.status}`} tone="default" />
+                ) : null}
+                {lastLogoutUpdated ? <StatusChip label={`updated ${lastLogoutUpdated}`} tone="default" /> : null}
+              </div>
+
+              <div className="mt-4 rounded-3xl border border-border bg-surface px-4 py-4">
+                <p className="text-xs font-semibold text-text-muted">Request URL</p>
+                <p className="mt-1 break-all text-sm text-text-secondary">
+                  {configurationError ? configurationError : logoutUrl}
+                </p>
+              </div>
+
+              <button
+                type="button"
+                disabled={Boolean(configurationError) || logoutMutation.isPending}
+                onClick={() => {
+                  if (configurationError) {
+                    return;
+                  }
+
+                  setLastLogoutRequestedAt(Date.now());
+                  logoutMutation.mutate();
+                }}
+                className="mt-4 flex h-12 w-full cursor-pointer items-center justify-center rounded-2xl border border-border bg-surface text-sm font-semibold text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                로그아웃 호출
+              </button>
+
+              <div className="mt-4 rounded-3xl border border-border bg-slate-950 px-4 py-4">
+                <p className="text-xs font-semibold text-slate-400">Response</p>
+                <pre className="mt-2 overflow-auto text-xs leading-6 text-slate-100">
+                  {logoutMutation.isError ? logoutMutation.error.message : logoutResponsePreview}
+                </pre>
+              </div>
+            </article>
+          </div>
+        </section>
+
+        <section className="rounded-[28px] border border-border bg-surface p-6 shadow-sm">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <h2 className="text-xl font-bold text-text-primary">Streamer Search Test</h2>
+              <p className="mt-1 text-sm text-text-secondary">
+                검색어를 입력하면 브라우저에서 `GET /streamers/search`를 직접 호출합니다.
+              </p>
+            </div>
+          </div>
+
+          {configurationError ? (
+            <div className="mb-4 rounded-3xl border border-rose-200 bg-rose-50 px-4 py-4 text-sm text-rose-700">
+              {configurationError} `web/.env.local`에 `NEXT_PUBLIC_API_BASE_URL`을 설정하세요.
+            </div>
+          ) : null}
+
+          <form
+            className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_auto_auto]"
+            onSubmit={(event) => {
+              event.preventDefault();
+
+              if (configurationError) {
+                return;
+              }
+
+              const normalizedKeyword = keyword.trim();
+
+              if (normalizedKeyword.length === 0) {
+                return;
+              }
+
+              if (normalizedKeyword === submittedKeyword) {
+                void searchQuery.refetch();
+                return;
+              }
+
+              setSubmittedKeyword(normalizedKeyword);
+            }}
+          >
+            <label className="block">
+              <span className="mb-2 block text-sm font-semibold text-text-primary">keyword</span>
+              <div className="relative">
+                <span className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-text-muted">
+                  <SearchIcon />
+                </span>
+                <input
+                  value={keyword}
+                  onChange={(event) => {
+                    setKeyword(event.target.value);
+                  }}
+                  placeholder="예: 녹두로"
+                  className="h-12 w-full rounded-2xl border border-border bg-surface px-4 pl-11 text-sm text-text-primary outline-none transition focus:border-violet-300"
+                />
+              </div>
+            </label>
+
+            <button
+              type="submit"
+              disabled={Boolean(configurationError) || keyword.trim().length === 0 || searchQuery.isFetching}
+              className="h-12 rounded-2xl bg-slate-950 px-5 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              조회하기
+            </button>
+
+            <button
+              type="button"
+              onClick={() => {
+                setKeyword("");
+                setSubmittedKeyword("");
+              }}
+              className="h-12 rounded-2xl border border-border bg-surface px-5 text-sm font-semibold text-text-secondary"
+            >
+              초기화
+            </button>
+          </form>
+
+          <div className="mt-4 flex flex-wrap items-center gap-2">
+            <StatusChip
+              label={
+                searchQuery.isError
+                  ? "호출 실패"
+                  : searchQuery.isFetching
+                    ? "호출 중"
+                    : searchQuery.isSuccess
+                      ? "호출 성공"
+                      : "대기 중"
+              }
+              tone={searchQuery.isError ? "error" : searchQuery.isSuccess ? "success" : "default"}
+            />
+            {submittedKeyword ? <StatusChip label={`keyword ${submittedKeyword}`} tone="default" /> : null}
+            {searchQuery.isSuccess ? (
+              <StatusChip label={`results ${searchQuery.data?.length ?? 0}`} tone="default" />
+            ) : null}
+            {lastSearchUpdated ? <StatusChip label={`updated ${lastSearchUpdated}`} tone="default" /> : null}
+            {submittedKeyword ? (
+              <button
+                type="button"
+                onClick={() => {
+                  void searchQuery.refetch();
+                }}
+                className="inline-flex items-center gap-2 rounded-full border border-border bg-surface-muted px-3 py-1.5 text-xs font-semibold text-text-secondary"
+              >
+                <RefreshIcon />
+                다시 호출
+              </button>
+            ) : null}
+          </div>
+
+          <div className="mt-4 rounded-3xl border border-border bg-surface-muted px-4 py-4">
+            <p className="text-xs font-semibold text-text-muted">Request URL</p>
+            <p className="mt-1 break-all text-sm text-text-secondary">{requestUrl}</p>
+          </div>
+        </section>
+
+        <div className="grid gap-5 xl:grid-cols-[minmax(0,1.2fr)_minmax(360px,0.8fr)]">
+          <section className="rounded-[28px] border border-border bg-surface p-6 shadow-sm">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <h2 className="text-xl font-bold text-text-primary">검색 결과</h2>
+                <p className="mt-1 text-sm text-text-secondary">
+                  API에서 받은 스트리머 목록을 카드 형태로 그대로 보여줍니다.
+                </p>
+              </div>
+            </div>
+
+            <div className="mt-4 space-y-3">
+              {submittedKeyword.length === 0 ? (
+                <div className="rounded-3xl border border-dashed border-border px-5 py-12 text-center text-sm text-text-secondary">
+                  검색어를 입력한 뒤 조회를 실행하세요.
+                </div>
+              ) : searchQuery.isFetching ? (
+                <div className="rounded-3xl border border-dashed border-border px-5 py-12 text-center text-sm text-text-secondary">
+                  응답을 불러오는 중입니다.
+                </div>
+              ) : searchQuery.isError ? (
+                <div className="rounded-3xl border border-rose-200 bg-rose-50 px-5 py-12 text-center text-sm text-rose-700">
+                  {searchQuery.error.message}
+                </div>
+              ) : hasResults ? (
+                searchQuery.data?.map((streamer) => (
+                  <ResultCard key={streamer.id} streamer={streamer} />
+                ))
+              ) : (
+                <div className="rounded-3xl border border-dashed border-border px-5 py-12 text-center text-sm text-text-secondary">
+                  검색 결과가 없습니다.
+                </div>
+              )}
+            </div>
+          </section>
+
+          <section className="rounded-[28px] border border-border bg-surface p-6 shadow-sm">
+            <h2 className="text-xl font-bold text-text-primary">Raw JSON</h2>
+            <p className="mt-1 text-sm text-text-secondary">
+              프록시 응답을 그대로 확인할 수 있게 JSON도 함께 노출합니다.
+            </p>
+
+            <pre className="mt-4 max-h-[640px] overflow-auto rounded-3xl bg-slate-950 px-4 py-4 text-xs leading-6 text-slate-100">
+              {JSON.stringify(searchQuery.data ?? [], null, 2)}
+            </pre>
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/web/src/app/(main)/draft/create/page.tsx
+++ b/web/src/app/(main)/draft/create/page.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
+  Suspense,
   useEffect,
   useMemo,
   useRef,
@@ -500,7 +501,7 @@ function SelectField({
   );
 }
 
-export default function DraftCreatePage() {
+function DraftCreatePageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const participationMode = sanitizeParticipationMode(searchParams.get("mode"));
@@ -1560,5 +1561,21 @@ export default function DraftCreatePage() {
         </div>
       </div>
     </main>
+  );
+}
+
+export default function DraftCreatePage() {
+  return (
+    <Suspense
+      fallback={
+        <main className="min-h-[calc(100dvh-var(--header-height))] bg-background px-6 py-6 xl:px-8">
+          <section className="rounded-3xl border border-border bg-surface p-6 text-sm font-semibold text-text-secondary shadow-sm">
+            방 설정을 불러오는 중입니다.
+          </section>
+        </main>
+      }
+    >
+      <DraftCreatePageContent />
+    </Suspense>
   );
 }

--- a/web/src/app/(main)/draft/page.tsx
+++ b/web/src/app/(main)/draft/page.tsx
@@ -492,6 +492,16 @@ export default function Page() {
               <span>방 생성하기</span>
               <ArrowRightIcon />
             </button>
+
+            <button
+              type="button"
+              onClick={() => {
+                router.push("/draft/api-test");
+              }}
+              className="mt-3 flex h-12 w-full cursor-pointer items-center justify-center rounded-2xl border border-slate-200 bg-slate-50 text-sm font-semibold text-slate-700"
+            >
+              API 연동 테스트
+            </button>
           </aside>
         </div>
       </div>

--- a/web/src/app/(main)/draft/page.tsx
+++ b/web/src/app/(main)/draft/page.tsx
@@ -502,6 +502,16 @@ export default function Page() {
             >
               API 연동 테스트
             </button>
+
+            <button
+              type="button"
+              onClick={() => {
+                router.push("/drafts/ws-test");
+              }}
+              className="mt-2 flex h-12 w-full cursor-pointer items-center justify-center rounded-2xl border border-slate-200 bg-white text-sm font-semibold text-slate-700"
+            >
+              웹 소켓 연동 테스트
+            </button>
           </aside>
         </div>
       </div>

--- a/web/src/app/(main)/draft/snake/page.tsx
+++ b/web/src/app/(main)/draft/snake/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useState, type DragEvent, type ReactNode } from "react";
+import { Suspense, useEffect, useMemo, useState, type DragEvent, type ReactNode } from "react";
 import { useSearchParams } from "next/navigation";
 import { DraftStreamerCard } from "@/components/draft/streamer-card";
 import { STREAMER_DIRECTORY_BY_ID } from "@/constants/streamers";
@@ -188,7 +188,7 @@ function cloneAssignments(assignments: BoardAssignments): BoardAssignments {
   return nextAssignments;
 }
 
-export default function SnakeDraftPage() {
+function SnakeDraftPageContent() {
   const searchParams = useSearchParams();
   const snapshot = useMemo(() => parseDraftRoomSnapshot(searchParams.get("config")), [searchParams]);
   const [boardAssignments, setBoardAssignments] = useState<BoardAssignments>({});
@@ -841,5 +841,21 @@ export default function SnakeDraftPage() {
         </div>
       </div>
     </main>
+  );
+}
+
+export default function SnakeDraftPage() {
+  return (
+    <Suspense
+      fallback={
+        <main className="min-h-[calc(100dvh-var(--header-height))] bg-background px-6 py-6 xl:px-8">
+          <section className="rounded-3xl border border-border bg-surface p-6 text-sm font-semibold text-text-secondary shadow-sm">
+            드래프트 정보를 불러오는 중입니다.
+          </section>
+        </main>
+      }
+    >
+      <SnakeDraftPageContent />
+    </Suspense>
   );
 }

--- a/web/src/app/(main)/drafts/ws-test/page.tsx
+++ b/web/src/app/(main)/drafts/ws-test/page.tsx
@@ -1,0 +1,1142 @@
+"use client";
+
+import { useMutation } from "@tanstack/react-query";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { createDraftRoom, joinDraftRoomByInviteCode, startDraftRoom } from "@/apis/drafts";
+import { useDraftRoomStomp } from "@/hooks/drafts";
+import type { DraftParticipantSession, JoinDraftRoomResponse } from "@/types";
+import {
+  cn,
+  getDraftParticipantSession,
+  removeDraftParticipantSession,
+  saveDraftParticipantSession,
+} from "@/utils";
+
+const fixedTeamCount = 5;
+const fixedTeamSize = 5;
+
+type ChatPublisher = (content: string) => void;
+type DraftConnectionStatus = "idle" | "connecting" | "connected" | "disconnected" | "error";
+
+interface ReceivedMessage {
+  body: string;
+  id: string;
+  receivedAt: string;
+}
+
+interface SharedChatMessage {
+  content: string;
+  id: string;
+  nickname: string;
+  rawBody: string;
+  receivedAt: string;
+  receivedFromLabels: string[];
+  senderLabel: string;
+  senderRole: TestParticipantSession["role"] | null;
+  timestamp: string;
+  type: string;
+}
+
+interface TestParticipantSession extends DraftParticipantSession {
+  label: string;
+  role: "host" | "participant";
+}
+
+interface ChatSenderMetadata {
+  label: string;
+  role: TestParticipantSession["role"];
+}
+
+interface DraftRoomParticipantEventPayload {
+  newParticipant?: string;
+  nicknames?: Array<string | null>;
+}
+
+function ArrowLeftIcon() {
+  return (
+    <svg viewBox="0 0 20 20" fill="none" className="size-4" aria-hidden="true">
+      <path d="M15 10H5" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+      <path
+        d="m9 5-5 5 5 5"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function CopyIcon() {
+  return (
+    <svg viewBox="0 0 20 20" fill="none" className="size-4" aria-hidden="true">
+      <rect x="7" y="4" width="9" height="11" rx="2" stroke="currentColor" strokeWidth="1.8" />
+      <path
+        d="M4 7.5V6a2 2 0 0 1 2-2h6"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+      />
+      <path
+        d="M4 8.5V14a2 2 0 0 0 2 2h5"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+function SendIcon() {
+  return (
+    <svg viewBox="0 0 20 20" fill="none" className="size-4" aria-hidden="true">
+      <path d="M17 3 8.5 11.5" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+      <path
+        d="M17 3 12.5 17 8.5 11.5 3 8 17 3Z"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function SectionCard({
+  children,
+  description,
+  title,
+}: {
+  children: ReactNode;
+  description: string;
+  title: string;
+}) {
+  return (
+    <section className="rounded-3xl border border-border bg-surface p-5 shadow-sm">
+      <h2 className="text-xl font-bold tracking-[-0.03em] text-text-primary">{title}</h2>
+      <p className="mt-2 text-sm leading-6 text-text-secondary">{description}</p>
+      <div className="mt-5">{children}</div>
+    </section>
+  );
+}
+
+function StatusChip({
+  children,
+  tone = "default",
+}: {
+  children: ReactNode;
+  tone?: "default" | "error" | "success" | "warning";
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex h-8 items-center rounded-full border px-3 text-xs font-semibold",
+        tone === "success"
+          ? "border-emerald-200 bg-emerald-50 text-emerald-700"
+          : tone === "error"
+            ? "border-rose-200 bg-rose-50 text-rose-700"
+            : tone === "warning"
+              ? "border-amber-200 bg-amber-50 text-amber-700"
+              : "border-border bg-surface-muted text-text-secondary",
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-2xl border border-border bg-surface-muted px-4 py-3">
+      <p className="text-xs font-semibold text-text-muted">{label}</p>
+      <p className="mt-1 break-all text-sm font-semibold text-text-primary">{value}</p>
+    </div>
+  );
+}
+
+function CompactMetric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="inline-flex h-14 w-28 flex-col justify-center rounded-xl border border-border bg-surface-muted px-3">
+      <p className="text-[11px] font-semibold text-text-muted">{label}</p>
+      <p className="mt-0.5 text-sm font-bold text-text-primary">{value}</p>
+    </div>
+  );
+}
+
+function ParticipantInfoCard({ session }: { session: TestParticipantSession }) {
+  return (
+    <article className="rounded-2xl border border-border bg-surface-muted px-4 py-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h3 className="text-sm font-bold text-text-primary">{session.label}</h3>
+        <StatusChip>{session.label}</StatusChip>
+      </div>
+      <div className="mt-3">
+        <p className="text-xs font-semibold text-text-muted">token</p>
+        <p className="mt-1 break-all text-sm font-semibold text-text-primary">
+          {session.participantToken}
+        </p>
+      </div>
+    </article>
+  );
+}
+
+function MessageList({
+  emptyText,
+  messages,
+  title,
+}: {
+  emptyText: string;
+  messages: ReceivedMessage[];
+  title: string;
+}) {
+  return (
+    <div className="rounded-3xl border border-border bg-slate-950 px-4 py-4">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-sm font-semibold text-slate-100">{title}</p>
+        <StatusChip>{messages.length}개</StatusChip>
+      </div>
+
+      <div className="mt-3 max-h-56 space-y-3 overflow-auto">
+        {messages.length === 0 ? (
+          <p className="rounded-2xl border border-slate-800 px-4 py-8 text-center text-sm text-slate-400">
+            {emptyText}
+          </p>
+        ) : (
+          messages.map((message) => (
+            <article key={message.id} className="rounded-2xl border border-slate-800 px-3 py-3">
+              <p className="text-xs font-semibold text-slate-500">{message.receivedAt}</p>
+              <pre className="mt-2 whitespace-pre-wrap break-all text-xs leading-5 text-slate-100">
+                {message.body}
+              </pre>
+            </article>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+function createInviteLink(inviteCode: string) {
+  return `https://pickz.co.kr/join/${inviteCode}`;
+}
+
+function getDisplayNickname(nickname: string | undefined, fallbackLabel: string) {
+  const normalizedNickname = nickname?.trim();
+
+  if (!normalizedNickname || normalizedNickname === "null") {
+    return fallbackLabel;
+  }
+
+  return normalizedNickname;
+}
+
+function createReceivedMessage(body: string): ReceivedMessage {
+  return {
+    body,
+    id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    receivedAt: new Date().toLocaleTimeString("ko-KR", { hour12: false }),
+  };
+}
+
+function parseChatMessage(rawBody: string) {
+  try {
+    const parsedValue = JSON.parse(rawBody) as Record<string, unknown>;
+    const nickname =
+      typeof parsedValue.nickname === "string" &&
+      parsedValue.nickname.trim().length > 0 &&
+      parsedValue.nickname !== "null"
+        ? parsedValue.nickname
+        : "";
+
+    return {
+      content: typeof parsedValue.content === "string" ? parsedValue.content : rawBody,
+      nickname,
+      timestamp: typeof parsedValue.timestamp === "string" ? parsedValue.timestamp : "",
+      type: typeof parsedValue.type === "string" ? parsedValue.type : "",
+    };
+  } catch {
+    return {
+      content: rawBody,
+      nickname: "",
+      timestamp: "",
+      type: "",
+    };
+  }
+}
+
+function parseDraftRoomParticipantEvent(rawBody: string): DraftRoomParticipantEventPayload | null {
+  try {
+    const parsedValue = JSON.parse(rawBody) as Record<string, unknown>;
+    const eventPayload =
+      parsedValue.payload && typeof parsedValue.payload === "object"
+        ? (parsedValue.payload as Record<string, unknown>)
+        : parsedValue;
+    const rawNicknames = Array.isArray(eventPayload.nicknames) ? eventPayload.nicknames : null;
+    const nicknames = rawNicknames?.map((nickname) => {
+      if (typeof nickname !== "string") {
+        return null;
+      }
+
+      const trimmedNickname = nickname.trim();
+
+      return trimmedNickname.length > 0 && trimmedNickname !== "null" ? trimmedNickname : null;
+    });
+    const newParticipant =
+      typeof eventPayload.newParticipant === "string" && eventPayload.newParticipant.trim().length > 0
+        ? eventPayload.newParticipant.trim()
+        : undefined;
+
+    if (!nicknames && !newParticipant) {
+      return null;
+    }
+
+    return {
+      newParticipant,
+      nicknames: nicknames ?? undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function createSharedChatMessage(
+  sourceLabel: string,
+  rawBody: string,
+  fallbackSender: ChatSenderMetadata | null = null,
+): SharedChatMessage {
+  const parsedMessage = parseChatMessage(rawBody);
+  const nickname = parsedMessage.nickname || fallbackSender?.label || "";
+  const senderRole = fallbackSender?.role ?? (nickname === "방장" ? "host" : null);
+
+  return {
+    ...parsedMessage,
+    id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    nickname,
+    rawBody,
+    receivedAt: new Date().toLocaleTimeString("ko-KR", { hour12: false }),
+    receivedFromLabels: [sourceLabel],
+    senderLabel: fallbackSender?.label ?? nickname,
+    senderRole,
+  };
+}
+
+function SharedChatPanel({
+  activeParticipantToken,
+  activeSessionStatus,
+  canPublishChat,
+  chatContent,
+  messages,
+  onActiveParticipantTokenChange,
+  onChatContentChange,
+  onPublishChat,
+  sessions,
+}: {
+  activeParticipantToken: string;
+  activeSessionStatus: DraftConnectionStatus;
+  canPublishChat: boolean;
+  chatContent: string;
+  messages: SharedChatMessage[];
+  onActiveParticipantTokenChange: (participantToken: string) => void;
+  onChatContentChange: (content: string) => void;
+  onPublishChat: () => void;
+  sessions: TestParticipantSession[];
+}) {
+  const activeSession = sessions.find((session) => session.participantToken === activeParticipantToken) ?? null;
+  const orderedMessages = [...messages].reverse();
+
+  return (
+    <SectionCard
+      title="통합 채팅"
+      description="전체 채팅을 한 대화창에서 보고, 아래 탭으로 발신자를 바꿔 바로 메시지를 보냅니다."
+    >
+      <div className="overflow-hidden rounded-3xl border border-border bg-surface shadow-sm">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="px-5 pt-4">
+            <p className="text-sm font-bold text-text-primary">전체 채팅창</p>
+            <p className="mt-1 text-xs font-semibold text-text-muted">
+              {activeSession ? `${activeSession.label}로 입력 중` : "방 생성 후 채팅 가능"}
+            </p>
+          </div>
+          <div className="px-5 pt-4">
+            <StatusChip>{messages.length}개</StatusChip>
+          </div>
+        </div>
+
+        <div className="mt-4 flex h-[420px] flex-col gap-4 overflow-auto bg-surface-muted px-5 py-5">
+          {messages.length === 0 ? (
+            <div className="m-auto rounded-2xl border border-dashed border-border bg-surface px-5 py-8 text-center">
+              <p className="text-sm font-semibold text-text-primary">아직 채팅이 없습니다.</p>
+              <p className="mt-1 text-xs text-text-muted">아래 탭에서 발신자를 고르고 메시지를 보내세요.</p>
+            </div>
+          ) : (
+            orderedMessages.map((message) => {
+              const isHostMessage = message.senderRole === "host" || message.nickname === "방장";
+
+              return (
+                <article
+                  key={message.id}
+                  className={cn("flex flex-col gap-1.5", isHostMessage ? "items-end" : "items-start")}
+                >
+                  <div
+                    className={cn(
+                      "flex max-w-[82%] flex-col",
+                      isHostMessage ? "items-end" : "items-start",
+                    )}
+                  >
+                    <div
+                      className={cn(
+                        "flex flex-wrap items-center gap-2 px-1",
+                        isHostMessage ? "justify-end" : "justify-start",
+                      )}
+                    >
+                      <span className="text-xs font-bold text-text-primary">
+                        {message.nickname || message.senderLabel || "보낸 사람 미확인"}
+                      </span>
+                      <span className="text-[11px] font-semibold text-text-muted">
+                        {message.timestamp || message.receivedAt}
+                      </span>
+                    </div>
+                    <div
+                      className={cn(
+                        "mt-1 rounded-2xl border px-4 py-3 shadow-sm",
+                        isHostMessage
+                          ? "rounded-tr-md border-slate-950 bg-slate-950 text-white"
+                          : "rounded-tl-md border-border bg-surface text-text-primary",
+                      )}
+                    >
+                      <p className="whitespace-pre-wrap break-words text-sm font-medium leading-6">
+                        {message.content}
+                      </p>
+                    </div>
+                    <p className="mt-1 px-1 text-[11px] font-semibold text-text-muted">
+                      수신: {message.receivedFromLabels.join(", ")}
+                    </p>
+                  </div>
+                </article>
+              );
+            })
+          )}
+        </div>
+
+        <div className="border-t border-border bg-surface px-4 py-4">
+          <div className="flex flex-wrap gap-2">
+          {sessions.length === 0 ? (
+            <StatusChip>방 생성 후 발신자 탭이 표시됩니다.</StatusChip>
+          ) : (
+            sessions.map((session) => {
+              const isActive = session.participantToken === activeParticipantToken;
+
+              return (
+                <button
+                  key={session.participantToken}
+                  type="button"
+                  onClick={() => {
+                    onActiveParticipantTokenChange(session.participantToken);
+                  }}
+                  className={cn(
+                    "inline-flex h-9 items-center rounded-full border px-3 text-xs font-bold transition-colors",
+                    isActive
+                      ? "border-slate-950 bg-slate-950 text-white"
+                      : "border-border bg-surface text-text-secondary hover:text-text-primary",
+                  )}
+                >
+                  {session.label}
+                </button>
+              );
+            })
+          )}
+          </div>
+
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <StatusChip>발신자: {activeSession?.label ?? "없음"}</StatusChip>
+            <StatusChip tone={activeSessionStatus === "connected" ? "success" : "warning"}>
+              연결 상태: {activeSessionStatus}
+            </StatusChip>
+            {activeSession?.role === "host" ? <StatusChip>방장</StatusChip> : null}
+          </div>
+
+          <div className="mt-3 flex gap-2">
+            <input
+              value={chatContent}
+              onChange={(event) => {
+                onChatContentChange(event.target.value);
+              }}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && canPublishChat) {
+                  onPublishChat();
+                }
+              }}
+              placeholder={activeSession ? `${activeSession.label} 메시지 입력` : "방 생성 후 채팅 가능"}
+              className="h-12 min-w-0 flex-1 rounded-2xl border border-border bg-surface-muted px-4 text-sm text-text-primary outline-none transition focus:border-violet-300"
+            />
+            <button
+              type="button"
+              disabled={!canPublishChat}
+              onClick={onPublishChat}
+              className="inline-flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-slate-950 text-white disabled:cursor-not-allowed disabled:opacity-50"
+              aria-label="채팅 보내기"
+            >
+              <SendIcon />
+            </button>
+          </div>
+        </div>
+      </div>
+    </SectionCard>
+  );
+}
+
+function DraftRoomRealtimeTester({
+  onRoomEvent,
+  onRegisterChatPublisher,
+  onSharedChatMessage,
+  onUnregisterChatPublisher,
+  session,
+}: {
+  onRoomEvent: (messageBody: string) => void;
+  onRegisterChatPublisher: (
+    session: TestParticipantSession,
+    publisher: ChatPublisher,
+    status: DraftConnectionStatus,
+  ) => void;
+  onSharedChatMessage: (sourceLabel: string, messageBody: string) => void;
+  onUnregisterChatPublisher: (participantToken: string) => void;
+  session: TestParticipantSession;
+}) {
+  const [roomMessages, setRoomMessages] = useState<ReceivedMessage[]>([]);
+  const [errorMessages, setErrorMessages] = useState<ReceivedMessage[]>([]);
+  const [connectionErrorMessage, setConnectionErrorMessage] = useState("");
+
+  const handleRoomMessage = useCallback((messageBody: string) => {
+    setRoomMessages((currentMessages) => [createReceivedMessage(messageBody), ...currentMessages].slice(0, 30));
+    onRoomEvent(messageBody);
+  }, [onRoomEvent]);
+
+  const handleChatMessage = useCallback(
+    (messageBody: string) => {
+      onSharedChatMessage(session.label, messageBody);
+    },
+    [onSharedChatMessage, session.label],
+  );
+
+  const handleErrorMessage = useCallback((messageBody: string) => {
+    setErrorMessages((currentMessages) => [createReceivedMessage(messageBody), ...currentMessages].slice(0, 30));
+  }, []);
+
+  const { connectionStatus, publishChat } = useDraftRoomStomp({
+    roomId: session.roomId,
+    participantToken: session.participantToken,
+    onChatMessage: handleChatMessage,
+    onConnectionError: setConnectionErrorMessage,
+    onRoomMessage: handleRoomMessage,
+    onErrorMessage: handleErrorMessage,
+  });
+
+  useEffect(() => {
+    onRegisterChatPublisher(session, publishChat, connectionStatus);
+
+    return () => {
+      onUnregisterChatPublisher(session.participantToken);
+    };
+  }, [connectionStatus, onRegisterChatPublisher, onUnregisterChatPublisher, publishChat, session]);
+
+  const connectionTone = useMemo(() => {
+    if (connectionStatus === "connected") {
+      return "success";
+    }
+
+    if (connectionStatus === "error") {
+      return "error";
+    }
+
+    if (connectionStatus === "connecting") {
+      return "warning";
+    }
+
+    return "default";
+  }, [connectionStatus]);
+
+  return (
+    <SectionCard
+      title={`${session.label} 실시간 연결`}
+      description="방 이벤트와 개인 에러를 확인합니다. 채팅 발신은 통합 채팅창 아래 탭에서 처리합니다."
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <StatusChip tone={connectionTone}>connectionStatus: {connectionStatus}</StatusChip>
+        <StatusChip>{session.role === "host" ? "방장" : "참가자"}</StatusChip>
+        <StatusChip>room topic: /topic/drafts/rooms/{session.roomId}</StatusChip>
+        <StatusChip>chat: /topic/drafts/rooms/{session.roomId}/chat</StatusChip>
+        <StatusChip>error: /user/queue/errors</StatusChip>
+      </div>
+
+      <div className="mt-4 grid gap-3 xl:grid-cols-2">
+        <DetailRow label="WebSocket URL" value={process.env.NEXT_PUBLIC_DRAFT_WS_URL ?? "미설정"} />
+        <DetailRow label="Chat Publish Destination" value={`/app/drafts/rooms/${session.roomId}/chat`} />
+      </div>
+
+      {connectionErrorMessage ? (
+        <div className="mt-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-700">
+          {connectionErrorMessage}
+        </div>
+      ) : null}
+
+      <div className="mt-5 grid gap-4 xl:grid-cols-2">
+        <MessageList
+          title="방 이벤트"
+          emptyText="아직 방 이벤트 메시지가 없습니다."
+          messages={roomMessages}
+        />
+        <MessageList
+          title="개인 에러"
+          emptyText="아직 개인 에러 메시지가 없습니다."
+          messages={errorMessages}
+        />
+      </div>
+    </SectionCard>
+  );
+}
+
+export default function DraftWebSocketTestPage() {
+  const chatPublishersRef = useRef(new Map<string, ChatPublisher>());
+  const pendingChatSenderByContentRef = useRef(new Map<string, ChatSenderMetadata>());
+  const [hostSession, setHostSession] = useState<TestParticipantSession | null>(null);
+  const [participantSessions, setParticipantSessions] = useState<TestParticipantSession[]>([]);
+  const [connectionStatusByParticipantToken, setConnectionStatusByParticipantToken] = useState<
+    Record<string, DraftConnectionStatus>
+  >({});
+  const [activeChatParticipantToken, setActiveChatParticipantToken] = useState("");
+  const [chatContent, setChatContent] = useState("");
+  const [sharedChatMessages, setSharedChatMessages] = useState<SharedChatMessage[]>([]);
+  const [isParticipantSessionSaved, setIsParticipantSessionSaved] = useState(false);
+  const [inviteLinkCopyStatus, setInviteLinkCopyStatus] = useState("");
+
+  const allSessions = useMemo(
+    () => (hostSession ? [hostSession, ...participantSessions] : []),
+    [hostSession, participantSessions],
+  );
+  const totalParticipantCount = allSessions.length;
+  const requiredGuestCount = hostSession ? fixedTeamCount - 1 : 0;
+  const remainingGuestCount = Math.max(requiredGuestCount - participantSessions.length, 0);
+  const canJoinParticipant = Boolean(hostSession) && remainingGuestCount > 0;
+  const canStartRoom = Boolean(hostSession) && totalParticipantCount === fixedTeamCount;
+  const participantCountTone =
+    totalParticipantCount === fixedTeamCount
+      ? "success"
+      : totalParticipantCount > fixedTeamCount
+        ? "error"
+        : "warning";
+  const effectiveActiveChatParticipantToken = allSessions.some(
+    (session) => session.participantToken === activeChatParticipantToken,
+  )
+    ? activeChatParticipantToken
+    : (allSessions[0]?.participantToken ?? "");
+  const activeChatSession =
+    allSessions.find((session) => session.participantToken === effectiveActiveChatParticipantToken) ?? null;
+  const activeSessionStatus = activeChatSession
+    ? connectionStatusByParticipantToken[activeChatSession.participantToken] ?? "idle"
+    : "idle";
+  const canPublishChat =
+    Boolean(activeChatSession) &&
+    activeSessionStatus === "connected" &&
+    chatContent.trim().length > 0;
+
+  const handleRegisterChatPublisher = useCallback(
+    (session: TestParticipantSession, publisher: ChatPublisher, status: DraftConnectionStatus) => {
+      chatPublishersRef.current.set(session.participantToken, publisher);
+      setConnectionStatusByParticipantToken((currentStatuses) => {
+        if (currentStatuses[session.participantToken] === status) {
+          return currentStatuses;
+        }
+
+        return {
+          ...currentStatuses,
+          [session.participantToken]: status,
+        };
+      });
+    },
+    [],
+  );
+  const handleUnregisterChatPublisher = useCallback((participantToken: string) => {
+    chatPublishersRef.current.delete(participantToken);
+    setConnectionStatusByParticipantToken((currentStatuses) => {
+      const nextStatuses = { ...currentStatuses };
+      delete nextStatuses[participantToken];
+
+      return nextStatuses;
+    });
+  }, []);
+  const appendParticipantSessions = useCallback(
+    (responses: JoinDraftRoomResponse[]) => {
+      if (!hostSession) {
+        return;
+      }
+
+      setParticipantSessions((currentSessions) => {
+        const nextSessions = [...currentSessions];
+
+        responses.forEach((response) => {
+          const participantNumber = nextSessions.length + 1;
+
+          nextSessions.push({
+            roomId: hostSession.roomId,
+            inviteCode: hostSession.inviteCode,
+            nickname: getDisplayNickname(response.nickname, `참가자 ${participantNumber}`),
+            participantToken: response.participantToken,
+            label: `참가자 ${participantNumber}`,
+            role: "participant",
+          });
+        });
+
+        return nextSessions.slice(0, requiredGuestCount);
+      });
+    },
+    [hostSession, requiredGuestCount],
+  );
+  const applyParticipantNicknamesFromRoomEvent = useCallback((messageBody: string) => {
+    const participantEvent = parseDraftRoomParticipantEvent(messageBody);
+
+    if (!participantEvent) {
+      return;
+    }
+
+    setParticipantSessions((currentSessions) => {
+      if (currentSessions.length === 0) {
+        return currentSessions;
+      }
+
+      let isChanged = false;
+      const normalizedNicknames = participantEvent.nicknames ?? [];
+      const shouldSkipFirstNickname =
+        normalizedNicknames.length >= currentSessions.length + 1 && normalizedNicknames[0] === null;
+      const nicknameStartIndex = shouldSkipFirstNickname ? 1 : 0;
+      const nextSessions = currentSessions.map((session, index) => {
+        const candidateNickname =
+          normalizedNicknames[nicknameStartIndex + index] ?? (index === currentSessions.length - 1 ? participantEvent.newParticipant : null);
+
+        if (!candidateNickname || candidateNickname === session.nickname) {
+          return session;
+        }
+
+        isChanged = true;
+
+        return {
+          ...session,
+          nickname: candidateNickname,
+        };
+      });
+
+      return isChanged ? nextSessions : currentSessions;
+    });
+  }, []);
+  const appendSharedChatMessage = useCallback((sourceLabel: string, messageBody: string) => {
+    setSharedChatMessages((currentMessages) => {
+      const matchedMessage = currentMessages.find((message) => message.rawBody === messageBody);
+
+      if (matchedMessage) {
+        return currentMessages.map((message) => {
+          if (message.id !== matchedMessage.id || message.receivedFromLabels.includes(sourceLabel)) {
+            return message;
+          }
+
+          return {
+            ...message,
+            receivedFromLabels: [...message.receivedFromLabels, sourceLabel],
+          };
+        });
+      }
+
+      const parsedMessage = parseChatMessage(messageBody);
+      const fallbackSender = pendingChatSenderByContentRef.current.get(parsedMessage.content) ?? null;
+      pendingChatSenderByContentRef.current.delete(parsedMessage.content);
+
+      return [createSharedChatMessage(sourceLabel, messageBody, fallbackSender), ...currentMessages].slice(0, 60);
+    });
+  }, []);
+
+  const createRoomMutation = useMutation({
+    mutationKey: ["draft-room-create"],
+    mutationFn: () => createDraftRoom(),
+    onSuccess: (response) => {
+      const nextSession: TestParticipantSession = {
+        roomId: response.roomId,
+        inviteCode: response.inviteCode,
+        nickname: getDisplayNickname(response.nickname, "방장"),
+        participantToken: response.participantToken,
+        label: "방장",
+        role: "host",
+      };
+
+      // 방장 세션은 기존 검증처럼 sessionStorage 저장 여부까지 확인함.
+      saveDraftParticipantSession(nextSession);
+      setHostSession(nextSession);
+      setParticipantSessions([]);
+      setActiveChatParticipantToken(nextSession.participantToken);
+      setSharedChatMessages([]);
+      setChatContent("");
+      pendingChatSenderByContentRef.current.clear();
+      setInviteLinkCopyStatus("");
+      setIsParticipantSessionSaved(Boolean(getDraftParticipantSession(nextSession.roomId)));
+    },
+  });
+  const joinRoomMutation = useMutation({
+    mutationKey: ["draft-room-join", hostSession?.inviteCode],
+    mutationFn: async () => {
+      if (!hostSession) {
+        throw new Error("먼저 방을 생성하세요.");
+      }
+
+      return joinDraftRoomByInviteCode(hostSession.inviteCode);
+    },
+    onSuccess: (response) => {
+      appendParticipantSessions([response]);
+    },
+  });
+  const joinRemainingParticipantsMutation = useMutation({
+    mutationKey: ["draft-room-join-remaining", hostSession?.inviteCode, remainingGuestCount],
+    mutationFn: async () => {
+      if (!hostSession) {
+        throw new Error("먼저 방을 생성하세요.");
+      }
+
+      const responses: JoinDraftRoomResponse[] = [];
+
+      for (let index = 0; index < remainingGuestCount; index += 1) {
+        responses.push(await joinDraftRoomByInviteCode(hostSession.inviteCode));
+      }
+
+      return responses;
+    },
+    onSuccess: (responses) => {
+      appendParticipantSessions(responses);
+    },
+  });
+  const startRoomMutation = useMutation({
+    mutationKey: ["draft-room-start", hostSession?.roomId, fixedTeamCount, fixedTeamSize],
+    mutationFn: async () => {
+      if (!hostSession) {
+        throw new Error("먼저 방을 생성하세요.");
+      }
+
+      if (totalParticipantCount !== fixedTeamCount) {
+        throw new Error(
+          `방장 포함 참여 인원이 ${fixedTeamCount}명이어야 합니다. 현재 ${totalParticipantCount}/${fixedTeamCount}명입니다.`,
+        );
+      }
+
+      return startDraftRoom({
+        roomId: hostSession.roomId,
+        participantToken: hostSession.participantToken,
+        request: {
+          teamCount: fixedTeamCount,
+          teamSize: fixedTeamSize,
+        },
+      });
+    },
+  });
+
+  const inviteLink = hostSession ? createInviteLink(hostSession.inviteCode) : "";
+  const handleCopyInviteLink = async () => {
+    if (!inviteLink) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(inviteLink);
+      setInviteLinkCopyStatus("초대 링크를 복사했습니다.");
+    } catch {
+      setInviteLinkCopyStatus("클립보드 복사에 실패했습니다. 링크를 직접 복사하세요.");
+    }
+  };
+  const handlePublishChat = () => {
+    const normalizedContent = chatContent.trim();
+
+    if (!activeChatSession || normalizedContent.length === 0) {
+      return;
+    }
+
+    const publisher = chatPublishersRef.current.get(activeChatSession.participantToken);
+
+    if (!publisher) {
+      return;
+    }
+
+    pendingChatSenderByContentRef.current.set(normalizedContent, {
+      label: getDisplayNickname(activeChatSession.nickname, activeChatSession.label),
+      role: activeChatSession.role,
+    });
+    publisher(normalizedContent);
+    setChatContent("");
+  };
+  const handleRemoveCreatedRoom = () => {
+    if (!hostSession) {
+      return;
+    }
+
+    // 서버 삭제 API가 아직 없으므로 테스트 페이지의 로컬 방 세션만 제거함.
+    removeDraftParticipantSession(hostSession.roomId);
+    chatPublishersRef.current.clear();
+    pendingChatSenderByContentRef.current.clear();
+    setHostSession(null);
+    setParticipantSessions([]);
+    setConnectionStatusByParticipantToken({});
+    setActiveChatParticipantToken("");
+    setChatContent("");
+    setSharedChatMessages([]);
+    setInviteLinkCopyStatus("");
+    setIsParticipantSessionSaved(false);
+    createRoomMutation.reset();
+    joinRoomMutation.reset();
+    joinRemainingParticipantsMutation.reset();
+    startRoomMutation.reset();
+  };
+
+  return (
+    <main className="min-h-[calc(100dvh-var(--header-height))] bg-background px-4 py-5 sm:px-6 xl:px-8">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-5">
+        <section className="rounded-3xl border border-border bg-surface p-5 shadow-sm">
+          <a
+            href="/draft"
+            className="inline-flex h-10 items-center justify-center gap-2 rounded-2xl border border-border bg-surface-muted px-4 text-sm font-semibold text-text-primary"
+          >
+            <ArrowLeftIcon />
+            <span>드래프트로 돌아가기</span>
+          </a>
+
+          <div className="mt-5 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+            <div>
+              <p className="text-xs font-bold tracking-[0.16em] text-violet-600 uppercase">
+                WAITING ROOM TEST
+              </p>
+              <h1 className="mt-2 text-3xl font-bold tracking-[-0.03em] text-text-primary">
+                드래프트 대기방 통합 테스트
+              </h1>
+              <p className="mt-2 max-w-3xl text-sm leading-6 text-text-secondary">
+                5팀 5인 고정 조건으로 방 생성, 참가자 입장, 게임 시작, 통합 채팅 송수신을 검증합니다.
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-2 sm:flex-row">
+              {hostSession ? (
+                <button
+                  type="button"
+                  onClick={handleRemoveCreatedRoom}
+                  className="inline-flex h-12 min-w-40 items-center justify-center rounded-2xl border border-rose-200 bg-rose-50 px-5 text-sm font-bold text-rose-700"
+                >
+                  방 제거
+                </button>
+              ) : null}
+              <button
+                type="button"
+                disabled={createRoomMutation.isPending}
+                onClick={() => {
+                  createRoomMutation.mutate();
+                }}
+                className="inline-flex h-12 min-w-40 items-center justify-center rounded-2xl bg-slate-950 px-5 text-sm font-bold text-white disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {createRoomMutation.isPending ? "방 생성 중" : "방 생성"}
+              </button>
+            </div>
+          </div>
+
+          {createRoomMutation.isError ? (
+            <div className="mt-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-700">
+              {createRoomMutation.error.message}
+            </div>
+          ) : null}
+        </section>
+
+        <SectionCard
+          title="방 생성 및 참가자 입장"
+          description="teamCount/teamSize는 5로 고정하고, 방장 1명 + 참가자 4명을 맞춘 뒤 게임 시작을 요청합니다."
+        >
+          {hostSession ? (
+            <div className="space-y-5">
+              <div className="flex flex-wrap items-center gap-2">
+                <StatusChip tone={participantCountTone}>
+                  방장 포함 참여 인원 {totalParticipantCount} / {fixedTeamCount}
+                </StatusChip>
+                <StatusChip>teamCount {fixedTeamCount}</StatusChip>
+                <StatusChip>teamSize {fixedTeamSize}</StatusChip>
+                <StatusChip>필요 참가자 {requiredGuestCount}명</StatusChip>
+                <StatusChip>남은 참가자 {remainingGuestCount}명</StatusChip>
+              </div>
+
+              <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+                <DetailRow label="roomId" value={String(hostSession.roomId)} />
+                <DetailRow label="inviteCode" value={hostSession.inviteCode} />
+                <DetailRow label="host participantToken" value={hostSession.participantToken} />
+                <DetailRow
+                  label="sessionStorage 저장"
+                  value={isParticipantSessionSaved ? "저장됨" : "저장 확인 실패"}
+                />
+                <DetailRow label="방 제거 방식" value="로컬 세션 제거 및 STOMP 연결 종료" />
+              </div>
+
+              <div className="grid gap-3 xl:grid-cols-[minmax(0,1fr)_auto_auto_auto]">
+                <DetailRow label="참여 링크" value={inviteLink} />
+                <button
+                  type="button"
+                  onClick={handleCopyInviteLink}
+                  className="inline-flex h-12 items-center justify-center gap-2 rounded-2xl border border-border bg-surface-muted px-4 text-sm font-bold text-text-primary"
+                >
+                  <CopyIcon />
+                  <span>참여 링크 복사</span>
+                </button>
+                <button
+                  type="button"
+                  disabled={!canJoinParticipant || joinRoomMutation.isPending || joinRemainingParticipantsMutation.isPending}
+                  onClick={() => {
+                    joinRoomMutation.mutate();
+                  }}
+                  className="inline-flex h-12 items-center justify-center rounded-2xl bg-slate-950 px-4 text-sm font-bold text-white disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {joinRoomMutation.isPending ? "참가 중" : "참가자 1명 입장"}
+                </button>
+                <button
+                  type="button"
+                  disabled={!canJoinParticipant || joinRoomMutation.isPending || joinRemainingParticipantsMutation.isPending}
+                  onClick={() => {
+                    joinRemainingParticipantsMutation.mutate();
+                  }}
+                  className="inline-flex h-12 items-center justify-center rounded-2xl border border-border bg-surface-muted px-4 text-sm font-bold text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {joinRemainingParticipantsMutation.isPending ? "전체 입장 중" : "남은 참가자 모두 입장"}
+                </button>
+              </div>
+
+              {inviteLinkCopyStatus ? (
+                <div className="rounded-2xl border border-border bg-surface-muted px-4 py-3 text-sm font-semibold text-text-secondary">
+                  {inviteLinkCopyStatus}
+                </div>
+              ) : null}
+              {joinRoomMutation.isError ? (
+                <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-700">
+                  {joinRoomMutation.error.message}
+                </div>
+              ) : null}
+              {joinRemainingParticipantsMutation.isError ? (
+                <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-700">
+                  {joinRemainingParticipantsMutation.error.message}
+                </div>
+              ) : null}
+
+              <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                {participantSessions.length === 0 ? (
+                  <div className="rounded-2xl border border-dashed border-border px-5 py-8 text-center text-sm text-text-secondary">
+                    참가자를 입장시키면 participantToken이 여기에 표시됩니다.
+                  </div>
+                ) : (
+                  participantSessions.map((participantSession) => (
+                    <ParticipantInfoCard
+                      key={participantSession.participantToken}
+                      session={participantSession}
+                    />
+                  ))
+                )}
+              </div>
+            </div>
+          ) : (
+            <div className="rounded-2xl border border-dashed border-border px-5 py-8 text-center text-sm text-text-secondary">
+              방 생성 버튼을 누르면 inviteCode, 방장 토큰, 참가자 입장 테스트가 열립니다.
+            </div>
+          )}
+        </SectionCard>
+
+        <SectionCard
+          title="게임 시작"
+          description="5팀 5인 고정값으로 PATCH /settings를 호출하고 WebSocket 게임 시작 이벤트를 확인합니다."
+        >
+          <div className="grid gap-4 xl:grid-cols-[auto_auto_auto_minmax(0,1fr)]">
+            <CompactMetric label="teamCount" value={String(fixedTeamCount)} />
+            <CompactMetric label="teamSize" value={String(fixedTeamSize)} />
+            <button
+              type="button"
+              disabled={!canStartRoom || startRoomMutation.isPending}
+              onClick={() => {
+                startRoomMutation.mutate();
+              }}
+              className="mt-auto inline-flex h-12 items-center justify-center rounded-2xl bg-slate-950 px-5 text-sm font-bold text-white disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {startRoomMutation.isPending ? "시작 요청 중" : "게임 시작 요청"}
+            </button>
+            <div className="rounded-2xl border border-border bg-surface-muted px-4 py-3">
+              <p className="text-xs font-semibold text-text-muted">Request</p>
+              <pre className="mt-1 text-xs leading-5 text-text-primary">
+                {JSON.stringify(
+                  {
+                    method: "PATCH",
+                    path: hostSession ? `/api/drafts/rooms/${hostSession.roomId}/settings` : "",
+                    headers: {
+                      "X-Participant-Token": hostSession?.participantToken ?? "",
+                    },
+                    body: { teamCount: fixedTeamCount, teamSize: fixedTeamSize },
+                    required: `방장 포함 ${fixedTeamCount}명 필요`,
+                    currentParticipants: totalParticipantCount,
+                  },
+                  null,
+                  2,
+                )}
+              </pre>
+            </div>
+          </div>
+
+          {!canStartRoom ? (
+            <div className="mt-4 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm font-semibold text-amber-700">
+              게임 시작 전 방장 포함 참여 인원을 {fixedTeamCount}명으로 맞춰야 합니다. 현재 {totalParticipantCount}/{fixedTeamCount}명입니다.
+            </div>
+          ) : null}
+          {startRoomMutation.isSuccess ? (
+            <div className="mt-4 rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm font-semibold text-emerald-700">
+              게임 시작 API가 성공했습니다. 방 이벤트 목록에서 redirectUrl 포함 메시지를 확인하세요.
+            </div>
+          ) : null}
+          {startRoomMutation.isError ? (
+            <div className="mt-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm font-semibold text-rose-700">
+              {startRoomMutation.error.message}
+            </div>
+          ) : null}
+        </SectionCard>
+
+        <SharedChatPanel
+          activeParticipantToken={effectiveActiveChatParticipantToken}
+          activeSessionStatus={activeSessionStatus}
+          canPublishChat={canPublishChat}
+          chatContent={chatContent}
+          messages={sharedChatMessages}
+          onActiveParticipantTokenChange={setActiveChatParticipantToken}
+          onChatContentChange={setChatContent}
+          onPublishChat={handlePublishChat}
+          sessions={allSessions}
+        />
+
+        <div className="grid gap-5">
+          {hostSession ? (
+            <DraftRoomRealtimeTester
+              key={`host-${hostSession.roomId}`}
+              onRoomEvent={applyParticipantNicknamesFromRoomEvent}
+              session={hostSession}
+              onRegisterChatPublisher={handleRegisterChatPublisher}
+              onSharedChatMessage={appendSharedChatMessage}
+              onUnregisterChatPublisher={handleUnregisterChatPublisher}
+            />
+          ) : null}
+          {participantSessions.map((participantSession) => (
+            <DraftRoomRealtimeTester
+              key={participantSession.participantToken}
+              onRoomEvent={applyParticipantNicknamesFromRoomEvent}
+              session={participantSession}
+              onRegisterChatPublisher={handleRegisterChatPublisher}
+              onSharedChatMessage={appendSharedChatMessage}
+              onUnregisterChatPublisher={handleUnregisterChatPublisher}
+            />
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -67,15 +67,15 @@
   --raw-gray-800: #1e293b;
   --raw-gray-900: #0f172a;
 
-  --raw-violet-100: #f3e8ff;
-  --raw-violet-200: #e9d5ff;
-  --raw-violet-300: #d8b4fe;
-  --raw-violet-400: #c084fc;
+  --raw-violet-100: #f0e6fd;
+  --raw-violet-200: #dac2fb;
+  --raw-violet-300: #bd91f8;
+  --raw-violet-400: #9f5ef4;
   --raw-violet-500: #6600ee;
-  --raw-violet-600: #5b21b6;
-  --raw-violet-700: #4c1d95;
-  --raw-violet-800: #3b0764;
-  --raw-violet-900: #2e1065;
+  --raw-violet-600: #5700ca;
+  --raw-violet-700: #4800a9;
+  --raw-violet-800: #3a0088;
+  --raw-violet-900: #2e006b;
 
   --raw-background-light: var(--raw-gray-100);
   --raw-foreground-light: var(--raw-gray-900);

--- a/web/src/hooks/drafts/index.ts
+++ b/web/src/hooks/drafts/index.ts
@@ -1,0 +1,1 @@
+export { useDraftRoomStomp } from "./use-draft-room-stomp";

--- a/web/src/hooks/drafts/use-draft-room-stomp.ts
+++ b/web/src/hooks/drafts/use-draft-room-stomp.ts
@@ -1,0 +1,209 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createDraftStompClient } from "@/libs/stomp";
+import type { Client, IMessage, StompSubscription } from "@stomp/stompjs";
+
+type DraftRoomStompConnectionStatus =
+  | "idle"
+  | "connecting"
+  | "connected"
+  | "disconnected"
+  | "error";
+
+interface UseDraftRoomStompParams {
+  roomId: number;
+  participantToken: string;
+  onChatMessage?: (messageBody: string) => void;
+  onConnectionError?: (messageBody: string) => void;
+  onRoomMessage?: (messageBody: string) => void;
+  onErrorMessage?: (messageBody: string) => void;
+}
+
+interface UseDraftRoomStompReturn {
+  connectionStatus: DraftRoomStompConnectionStatus;
+  publishChat: (content: string) => void;
+  publishPick: (streamerId: string) => void;
+}
+
+export function useDraftRoomStomp({
+  roomId,
+  participantToken,
+  onChatMessage,
+  onConnectionError,
+  onErrorMessage,
+  onRoomMessage,
+}: UseDraftRoomStompParams): UseDraftRoomStompReturn {
+  const [connectionStatus, setConnectionStatus] =
+    useState<DraftRoomStompConnectionStatus>("idle");
+  const clientRef = useRef<Client | null>(null);
+  const subscriptionsRef = useRef<StompSubscription[]>([]);
+  const onRoomMessageRef = useRef(onRoomMessage);
+  const onErrorMessageRef = useRef(onErrorMessage);
+  const onChatMessageRef = useRef(onChatMessage);
+  const onConnectionErrorRef = useRef(onConnectionError);
+
+  useEffect(() => {
+    onRoomMessageRef.current = onRoomMessage;
+  }, [onRoomMessage]);
+
+  useEffect(() => {
+    onErrorMessageRef.current = onErrorMessage;
+  }, [onErrorMessage]);
+
+  useEffect(() => {
+    onChatMessageRef.current = onChatMessage;
+  }, [onChatMessage]);
+
+  useEffect(() => {
+    onConnectionErrorRef.current = onConnectionError;
+  }, [onConnectionError]);
+
+  useEffect(() => {
+    let isCleanedUp = false;
+
+    const unsubscribeAll = () => {
+      // 재연결 또는 페이지 이탈 시 중복 구독이 남지 않게 정리함.
+      subscriptionsRef.current.forEach((subscription) => {
+        subscription.unsubscribe();
+      });
+      subscriptionsRef.current = [];
+    };
+
+    try {
+      const client = createDraftStompClient({
+        onConnect: () => {
+          if (isCleanedUp) {
+            return;
+          }
+
+          unsubscribeAll();
+
+          const roomSubscription = client.subscribe(
+            `/topic/drafts/rooms/${roomId}`,
+            (message: IMessage) => {
+              console.log("[draft room message]", message.body);
+              onRoomMessageRef.current?.(message.body);
+            },
+          );
+          const errorSubscription = client.subscribe(
+            "/user/queue/errors",
+            (message: IMessage) => {
+              console.warn("[draft room error]", message.body);
+              onErrorMessageRef.current?.(message.body);
+            },
+          );
+          const chatSubscription = client.subscribe(
+            `/topic/drafts/rooms/${roomId}/chat`,
+            (message: IMessage) => {
+              console.log("[draft room chat]", message.body);
+              onChatMessageRef.current?.(message.body);
+            },
+          );
+
+          subscriptionsRef.current = [roomSubscription, errorSubscription, chatSubscription];
+          setConnectionStatus("connected");
+        },
+        onDisconnect: () => {
+          if (!isCleanedUp) {
+            setConnectionStatus("disconnected");
+          }
+        },
+        onStompError: (frame) => {
+          const errorMessage = frame.body || frame.headers.message || "STOMP error";
+          console.warn("[draft stomp error]", errorMessage);
+
+          if (!isCleanedUp) {
+            setConnectionStatus("error");
+            onConnectionErrorRef.current?.(errorMessage);
+          }
+        },
+        onWebSocketError: (event) => {
+          console.warn("[draft websocket error]", event);
+
+          if (!isCleanedUp) {
+            setConnectionStatus("error");
+            onConnectionErrorRef.current?.(
+              "WebSocket 연결에 실패했습니다. NEXT_PUBLIC_DRAFT_WS_URL과 백엔드 WebSocket 배포 설정을 확인하세요.",
+            );
+          }
+        },
+      });
+
+      clientRef.current = client;
+      queueMicrotask(() => {
+        if (!isCleanedUp) {
+          setConnectionStatus("connecting");
+        }
+      });
+      client.activate();
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : "STOMP setup error";
+      console.warn("[draft stomp setup error]", errorMessage);
+      queueMicrotask(() => {
+        if (!isCleanedUp) {
+          setConnectionStatus("error");
+          onConnectionErrorRef.current?.(errorMessage);
+        }
+      });
+    }
+
+    return () => {
+      isCleanedUp = true;
+      unsubscribeAll();
+
+      const currentClient = clientRef.current;
+      clientRef.current = null;
+
+      if (currentClient) {
+        void currentClient.deactivate();
+      }
+    };
+  }, [roomId]);
+
+  const publishPick = useCallback(
+    (streamerId: string) => {
+      const client = clientRef.current;
+      const normalizedStreamerId = streamerId.trim();
+
+      if (!client?.connected || normalizedStreamerId.length === 0) {
+        return;
+      }
+
+      client.publish({
+        destination: `/app/drafts/rooms/${roomId}`,
+        body: JSON.stringify({
+          participantToken,
+          streamerId: normalizedStreamerId,
+        }),
+      });
+    },
+    [participantToken, roomId],
+  );
+
+  const publishChat = useCallback(
+    (content: string) => {
+      const client = clientRef.current;
+      const normalizedContent = content.trim();
+
+      if (!client?.connected || normalizedContent.length === 0) {
+        return;
+      }
+
+      client.publish({
+        destination: `/app/drafts/rooms/${roomId}/chat`,
+        body: JSON.stringify({
+          participantToken,
+          content: normalizedContent,
+        }),
+      });
+    },
+    [participantToken, roomId],
+  );
+
+  return {
+    connectionStatus,
+    publishChat,
+    publishPick,
+  };
+}

--- a/web/src/libs/stomp/create-draft-stomp-client.ts
+++ b/web/src/libs/stomp/create-draft-stomp-client.ts
@@ -1,0 +1,37 @@
+import { Client, type IFrame } from "@stomp/stompjs";
+
+interface CreateDraftStompClientParams {
+  onConnect?: (frame: IFrame) => void;
+  onDisconnect?: (frame: IFrame) => void;
+  onStompError?: (frame: IFrame) => void;
+  onWebSocketError?: (event: Event) => void;
+}
+
+function getDraftStompBrokerUrl() {
+  const brokerUrl = process.env.NEXT_PUBLIC_DRAFT_WS_URL?.trim() ?? "";
+
+  if (brokerUrl.length === 0) {
+    throw new Error("NEXT_PUBLIC_DRAFT_WS_URL 환경 변수가 없습니다.");
+  }
+
+  return brokerUrl;
+}
+
+export function createDraftStompClient({
+  onConnect,
+  onDisconnect,
+  onStompError,
+  onWebSocketError,
+}: CreateDraftStompClientParams = {}) {
+  return new Client({
+    brokerURL: getDraftStompBrokerUrl(),
+    heartbeatIncoming: 10000,
+    heartbeatOutgoing: 10000,
+    reconnectDelay: 5000,
+    // 현재 STOMP 연결 테스트는 인증 헤더 없이 진행함.
+    onConnect,
+    onDisconnect,
+    onStompError,
+    onWebSocketError,
+  });
+}

--- a/web/src/libs/stomp/index.ts
+++ b/web/src/libs/stomp/index.ts
@@ -1,0 +1,1 @@
+export { createDraftStompClient } from "./create-draft-stomp-client";

--- a/web/src/types/drafts/draft-room-event.ts
+++ b/web/src/types/drafts/draft-room-event.ts
@@ -1,0 +1,1 @@
+export type DraftRoomRawMessage = string;

--- a/web/src/types/drafts/draft-room.ts
+++ b/web/src/types/drafts/draft-room.ts
@@ -1,0 +1,36 @@
+export interface CreateDraftRoomRequest {
+  mode: "TOGETHER";
+  ruleName: "SNAKE";
+}
+
+export interface CreateDraftRoomResponse {
+  roomId: number;
+  inviteCode: string;
+  participantToken: string;
+  isHost?: boolean;
+  nickname?: string;
+}
+
+export interface DraftParticipantSession {
+  roomId: number;
+  inviteCode: string;
+  nickname?: string;
+  participantToken: string;
+}
+
+export interface JoinDraftRoomResponse {
+  participantToken: string;
+  isHost?: boolean;
+  nickname?: string;
+}
+
+export interface StartDraftRoomRequest {
+  teamCount: number;
+  teamSize: number;
+}
+
+export interface StartDraftRoomParams {
+  participantToken: string;
+  request: StartDraftRoomRequest;
+  roomId: number;
+}

--- a/web/src/types/drafts/index.ts
+++ b/web/src/types/drafts/index.ts
@@ -2,9 +2,8 @@ export type {
   CreateDraftRoomRequest,
   CreateDraftRoomResponse,
   DraftParticipantSession,
-  DraftRoomRawMessage,
   JoinDraftRoomResponse,
   StartDraftRoomParams,
   StartDraftRoomRequest,
-} from "./drafts";
-export type { MenuSidebarItem, MenuSidebarProps, SidebarContextValue } from "./sidebar";
+} from "./draft-room";
+export type { DraftRoomRawMessage } from "./draft-room-event";

--- a/web/src/utils/drafts/draft-participant-storage.ts
+++ b/web/src/utils/drafts/draft-participant-storage.ts
@@ -1,0 +1,72 @@
+import type { DraftParticipantSession } from "@/types";
+
+const draftParticipantStorageKeyPrefix = "pickz:draft-participant";
+
+function createDraftParticipantStorageKey(roomId: number) {
+  return `${draftParticipantStorageKeyPrefix}:${roomId}`;
+}
+
+function getSessionStorage() {
+  // sessionStorage는 브라우저에서만 접근 가능함.
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  return window.sessionStorage;
+}
+
+function isDraftParticipantSession(value: unknown): value is DraftParticipantSession {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const recordValue = value as Record<string, unknown>;
+
+  return (
+    typeof recordValue.roomId === "number" &&
+    typeof recordValue.inviteCode === "string" &&
+    typeof recordValue.participantToken === "string"
+  );
+}
+
+export function saveDraftParticipantSession(session: DraftParticipantSession) {
+  const storage = getSessionStorage();
+
+  if (!storage) {
+    return;
+  }
+
+  storage.setItem(createDraftParticipantStorageKey(session.roomId), JSON.stringify(session));
+}
+
+export function getDraftParticipantSession(roomId: number) {
+  const storage = getSessionStorage();
+
+  if (!storage) {
+    return null;
+  }
+
+  const storedValue = storage.getItem(createDraftParticipantStorageKey(roomId));
+
+  if (!storedValue) {
+    return null;
+  }
+
+  try {
+    const parsedValue = JSON.parse(storedValue) as unknown;
+
+    return isDraftParticipantSession(parsedValue) ? parsedValue : null;
+  } catch {
+    return null;
+  }
+}
+
+export function removeDraftParticipantSession(roomId: number) {
+  const storage = getSessionStorage();
+
+  if (!storage) {
+    return;
+  }
+
+  storage.removeItem(createDraftParticipantStorageKey(roomId));
+}

--- a/web/src/utils/drafts/index.ts
+++ b/web/src/utils/drafts/index.ts
@@ -1,0 +1,5 @@
+export {
+  getDraftParticipantSession,
+  removeDraftParticipantSession,
+  saveDraftParticipantSession,
+} from "./draft-participant-storage";

--- a/web/src/utils/index.ts
+++ b/web/src/utils/index.ts
@@ -1,5 +1,10 @@
 export { cn } from "./cn";
 export {
+  getDraftParticipantSession,
+  removeDraftParticipantSession,
+  saveDraftParticipantSession,
+} from "./drafts";
+export {
   draftLineLabelMap,
   draftLineRows,
   draftTypeLabelMap,


### PR DESCRIPTION
## 관련 이슈

- Closes #40 

## 작업 내용

> 이번 PR에서 작업한 내용을 작성해주세요.

- stompjs 라이브러리 설치
- 드래프트 방 생성, 초대코드 참여, 게임 시작 설정 API 연동 코드를 추가
- `/drafts/ws-test` 페이지에서 방 생성, 참가자 입장, 5x5 게임 시작, 채팅 송수신을 한 화면에서 테스트할 수 있도록 구성
    - 드래프트 페이지에 `웹 소켓 연동 테스트` 진입 버튼을 추가

## 특이사항

> 후속 작업, 영향 범위, 주의사항이 있으면 작성해주세요.

- 방 삭제 API가 아직 없어 `방 제거` 버튼은 서버 방 삭제가 아니라 로컬 세션과 STOMP 연결 상태만 정리하였습니다.
- 테스트를 위한 바이브 코딩임으로 실제 production 단계에 사용하기 위해서는 리팩토링이 필요

## 추가 정보

> UI 변경, 요청/응답 예시, 스크린샷 등이 있다면 첨부해주세요.
0. 드래프트 페이지 - 웹 소켓 테스트 페이지 이동
<img width="1232" height="820" alt="image" src="https://github.com/user-attachments/assets/3828c920-8ccb-4c3c-a746-bb0a104b6c84" />

1. 방 생성
 
<img width="1188" height="837" alt="image" src="https://github.com/user-attachments/assets/031a6616-a0c1-4439-a32d-ccca8183d3ba" />

2. 참가자 입장 시키기
<img width="1204" height="573" alt="image" src="https://github.com/user-attachments/assets/36fc52c5-f217-4fc9-9c4b-96239f3d6609" />

3. 채팅 테스트
<img width="1181" height="735" alt="image" src="https://github.com/user-attachments/assets/94d9ef3e-2bb7-4e7d-8f5f-befd1b6032c9" />

그 외) 게임 시작
- 게임 시작 성공한 것을 log를 통해 확인 가능
<img width="1895" height="782" alt="image" src="https://github.com/user-attachments/assets/3bbe60f6-7a33-4ddd-89c0-e27db7fdac32" />
