### PR TITLE
[api] feat: OAuth2 로그인 동적 리다이렉트 처리 구현

### DIFF
--- a/api/src/main/java/team/pickz/api/global/auth/presentation/AuthController.java
+++ b/api/src/main/java/team/pickz/api/global/auth/presentation/AuthController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.*;
 import team.pickz.api.global.annotation.MemberId;
 import team.pickz.api.global.auth.application.AuthService;
 import team.pickz.api.global.auth.application.dto.TokenResponse;
+import team.pickz.api.global.jwt.CookieUtil;
 
 @RequiredArgsConstructor
 @RequestMapping("/auths")
@@ -17,7 +18,14 @@ public class AuthController implements AuthDocsController{
     private final AuthService authService;
 
     @GetMapping("/login")
-    public String login() {
+    public String login(
+            @RequestParam(name = "redirect_uri", required = false) String redirectUri,
+            HttpServletResponse response
+    ) {
+        if(redirectUri != null && !redirectUri.isBlank()) {
+            CookieUtil.addCookie(response, "redirect_uri", redirectUri, 180);
+        }
+
         return "redirect:/oauth2/authorization/naver";
     }
 

--- a/api/src/main/java/team/pickz/api/global/auth/presentation/AuthController.java
+++ b/api/src/main/java/team/pickz/api/global/auth/presentation/AuthController.java
@@ -25,6 +25,9 @@ public class AuthController implements AuthDocsController{
         if(redirectUri != null && !redirectUri.isBlank()) {
             CookieUtil.addCookie(response, "redirect_uri", redirectUri, 180);
         }
+        else {
+            CookieUtil.deleteCookie(response, "redirect_uri");
+        }
 
         return "redirect:/oauth2/authorization/naver";
     }

--- a/api/src/main/java/team/pickz/api/global/auth/presentation/AuthDocsController.java
+++ b/api/src/main/java/team/pickz/api/global/auth/presentation/AuthDocsController.java
@@ -11,10 +11,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 import team.pickz.api.global.annotation.MemberId;
 import team.pickz.api.global.auth.application.dto.TokenResponse;
 import team.pickz.api.global.exception.ExceptionResponse;
@@ -31,7 +28,10 @@ public interface AuthDocsController {
             @ApiResponse(responseCode = "302", description = "네이버 인증 페이지로 Redirection")
     })
     @GetMapping("/login")
-    String login();
+    String login(
+            @RequestParam(name = "redirect_uri", required = false) String redirectUri,
+            HttpServletResponse response
+    );
 
     @Operation(
             summary = "access 토큰 재발급",

--- a/api/src/main/java/team/pickz/api/global/oauth2/OAuth2SuccessHandler.java
+++ b/api/src/main/java/team/pickz/api/global/oauth2/OAuth2SuccessHandler.java
@@ -1,5 +1,6 @@
 package team.pickz.api.global.oauth2;
 
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +14,7 @@ import team.pickz.api.global.jwt.JwtProvider;
 import team.pickz.api.global.jwt.config.TokenProperties;
 
 import java.io.IOException;
+import java.util.List;
 
 @RequiredArgsConstructor
 @Component
@@ -25,7 +27,13 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     private final AuthService authService;
 
     @Value("${spring.security.oAuthUrl.redirect-url}")
-    private String redirectUri;
+    private String defaultRedirectUri;
+
+    private final List<String> authorizedRedirectUris = List.of(
+            "http://localhost:3000",
+            "https://pickz.co.kr",
+            "https://www.pickz.co.kr"
+    );
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
@@ -33,13 +41,42 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         String accessToken = jwtProvider.createAccessToken(oAuth2User.getMemberId(), oAuth2User.getRole().getAuthority());
         String refreshToken = jwtProvider.createRefreshToken(oAuth2User.getMemberId(), oAuth2User.getRole().getAuthority());
-
         authService.saveRefreshToken(oAuth2User.getMemberId(), refreshToken);
 
         CookieUtil.addCookie(response, "access_token", accessToken, (int)tokenProperties.expirationTime().accessToken());
         CookieUtil.addCookie(response, "refresh_token", refreshToken, (int)tokenProperties.expirationTime().refreshToken());
 
-        getRedirectStrategy().sendRedirect(request, response, redirectUri);
+        String targetUrl = determineTargetUrl(request, response);
+
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+
+    @Override
+    protected String determineTargetUrl(HttpServletRequest request, HttpServletResponse response) {
+        String targetUrl = defaultRedirectUri;
+
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("redirect_uri".equals(cookie.getName())) {
+                    String redirectUriFromCookie = cookie.getValue();
+
+                    if (isAuthorizedRedirectUri(redirectUriFromCookie)) {
+                        targetUrl = redirectUriFromCookie;
+                    }
+
+                    cookie.setMaxAge(0);
+                    cookie.setPath("/");
+                    response.addCookie(cookie);
+                    break;
+                }
+            }
+        }
+        return targetUrl;
+    }
+
+    private boolean isAuthorizedRedirectUri(String uri) {
+        return authorizedRedirectUris.stream().anyMatch(uri::startsWith);
     }
 
 }

--- a/api/src/main/java/team/pickz/api/global/oauth2/OAuth2SuccessHandler.java
+++ b/api/src/main/java/team/pickz/api/global/oauth2/OAuth2SuccessHandler.java
@@ -14,7 +14,9 @@ import team.pickz.api.global.jwt.JwtProvider;
 import team.pickz.api.global.jwt.config.TokenProperties;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.List;
+import java.util.Objects;
 
 @RequiredArgsConstructor
 @Component
@@ -43,8 +45,8 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         String refreshToken = jwtProvider.createRefreshToken(oAuth2User.getMemberId(), oAuth2User.getRole().getAuthority());
         authService.saveRefreshToken(oAuth2User.getMemberId(), refreshToken);
 
-        CookieUtil.addCookie(response, "access_token", accessToken, (int)tokenProperties.expirationTime().accessToken());
-        CookieUtil.addCookie(response, "refresh_token", refreshToken, (int)tokenProperties.expirationTime().refreshToken());
+        CookieUtil.addCookie(response, "access_token", accessToken, (int) tokenProperties.expirationTime().accessToken());
+        CookieUtil.addCookie(response, "refresh_token", refreshToken, (int) tokenProperties.expirationTime().refreshToken());
 
         String targetUrl = determineTargetUrl(request, response);
 
@@ -76,7 +78,28 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     }
 
     private boolean isAuthorizedRedirectUri(String uri) {
-        return authorizedRedirectUris.stream().anyMatch(uri::startsWith);
+        try {
+            URI candidate = URI.create(uri);
+            int candidatePort = resolvePort(candidate);
+
+            return authorizedRedirectUris.stream()
+                    .map(URI::create)
+                    .anyMatch(allowed ->
+                            Objects.equals(allowed.getScheme(), candidate.getScheme())
+                                    && resolvePort(allowed) == candidatePort
+                    );
+        } catch (IllegalArgumentException ex) {
+            return false;
+        }
+    }
+
+    private int resolvePort(URI uri) {
+        if (uri.getPort() != -1) {
+            return uri.getPort();
+        }
+        return "https".equalsIgnoreCase(uri.getScheme()) ? 443 : 80;
     }
 
 }
+
+


### PR DESCRIPTION
## 관련 이슈

- Closes #45 

## 작업 내용

> 이번 PR에서 작업한 내용을 작성해주세요.

- AuthController: 프론트엔드에서 전달한 redirect_uri를 쿠키에 임시 저장
- OAuth2SuccessHandler: 로그인 완료 시 쿠키에서 redirect_uri를 읽어 리다이렉트 처리
- 보안 강화: 인가되지 않은 외부 도메인으로의 리다이렉트를 막기 위해 whitelist 검증 로직 추가
- 쿠키 정리: 리다이렉트 후 불필요해진 redirect_uri 쿠키 삭제 처리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 로그인 엔드포인트에서 리다이렉트 URI 파라미터를 지원합니다.
  * OAuth2 인증 완료 후 지정된 리다이렉트 주소로 사용자를 안내합니다.
  * 보안을 위해 승인된 주소 목록에 대해 리다이렉트를 검증합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->