### PR TITLE
[api] fix: Redirect URI 검증 시 Host 비교를 추가하여 오픈 리다이렉트 취약점 수정

### DIFF
--- a/api/src/main/java/team/pickz/api/global/oauth2/OAuth2SuccessHandler.java
+++ b/api/src/main/java/team/pickz/api/global/oauth2/OAuth2SuccessHandler.java
@@ -86,6 +86,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                     .map(URI::create)
                     .anyMatch(allowed ->
                             Objects.equals(allowed.getScheme(), candidate.getScheme())
+                                    && Objects.equals(allowed.getHost(), candidate.getHost())
                                     && resolvePort(allowed) == candidatePort
                     );
         } catch (IllegalArgumentException ex) {


### PR DESCRIPTION
## 관련 이슈

- Closes #47 

## 작업 내용

> 이번 PR에서 작업한 내용을 작성해주세요.

- Redirect URI 검증 로직 수정
- Scheme, Host, Port를 모두 비교하도록 변경
- 허용되지 않은 Host에 대한 리다이렉트 차단
- OAuth2 로그인 후 리다이렉트 검증 로직 테스트
- 오픈 리다이렉트 취약점 방지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* OAuth2 리다이렉트 URI 검증이 강화되었습니다. 이제 스킴, 포트와 함께 호스트 일치 여부도 확인합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->