### PR TITLE
[api] feat: 드래프트 참여 스트리머 추가 및 저장 기능 구현

### DIFF
--- a/api/src/main/java/team/pickz/api/domain/draft/application/DraftChatService.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/DraftChatService.java
@@ -7,7 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 import team.pickz.api.domain.draft.application.dto.request.ChatMessageRequest;
 import team.pickz.api.domain.draft.application.dto.response.ChatMessageResponse;
 import team.pickz.api.domain.draft.application.event.DraftChatEvent;
-import team.pickz.api.domain.draft.domain.MessageType;
+import team.pickz.api.domain.draft.domain.type.MessageType;
 import team.pickz.api.domain.draft.domain.entity.DraftParticipant;
 import team.pickz.api.domain.draft.domain.repository.DraftParticipantRepository;
 

--- a/api/src/main/java/team/pickz/api/domain/draft/application/DraftPlayService.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/DraftPlayService.java
@@ -7,6 +7,8 @@ import org.springframework.transaction.annotation.Transactional;
 import team.pickz.api.domain.draft.application.dto.response.PickResultResponse;
 import team.pickz.api.domain.draft.application.event.DraftPickedEvent;
 import team.pickz.api.domain.draft.application.util.RoomSequenceManager;
+import team.pickz.api.domain.draft.domain.entity.DraftRoomStreamer;
+import team.pickz.api.domain.draft.domain.repository.DraftRoomStreamerRepository;
 import team.pickz.api.domain.draft.domain.type.RoomStatus;
 import team.pickz.api.domain.draft.domain.entity.DraftParticipant;
 import team.pickz.api.domain.draft.domain.entity.DraftPick;
@@ -25,6 +27,7 @@ public class DraftPlayService {
     private final DraftRoomRepository draftRoomRepository;
     private final DraftParticipantRepository draftParticipantRepository;
     private final DraftPickRepository draftPickRepository;
+    private final DraftRoomStreamerRepository draftRoomStreamerRepository;
     private final DraftRule snakeDraftRule;
     private final ApplicationEventPublisher applicationEventPublisher;
     private final RoomSequenceManager roomSequenceManager;
@@ -56,6 +59,9 @@ public class DraftPlayService {
             throw new IllegalArgumentException("이미 선택된 스트리머입니다.");
         }
 
+        DraftRoomStreamer pickedStreamer = draftRoomStreamerRepository.findByRoomIdAndStreamerName(roomId, streamerId)
+                .orElseThrow(() -> new IllegalArgumentException("드래프트 풀에 존재하지 않는 스트리머입니다."));
+
         int currentRound = room.getCurrentPickCount() / room.getTeamCount();
         DraftPick pick = DraftPick.builder()
                 .roomId(roomId)
@@ -82,7 +88,9 @@ public class DraftPlayService {
                 .roomId(roomId)
                 .pickedNickname(requestor.getNickname())
                 .pickedStreamerId(streamerId)
-                .nextTurnNickname(nextTurnNickname) // 다음 차례 유저의 닉네임을 UI에 표시
+                .pickedStreamerName(pickedStreamer.getStreamerName())
+                .pickedStreamerImageUrl(pickedStreamer.getImageUrl())
+                .nextTurnNickname(nextTurnNickname)
                 .isDraftDone(room.getStatus() == RoomStatus.DONE)
                 .build();
 

--- a/api/src/main/java/team/pickz/api/domain/draft/application/DraftPlayService.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/DraftPlayService.java
@@ -7,7 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 import team.pickz.api.domain.draft.application.dto.response.PickResultResponse;
 import team.pickz.api.domain.draft.application.event.DraftPickedEvent;
 import team.pickz.api.domain.draft.application.util.RoomSequenceManager;
-import team.pickz.api.domain.draft.domain.RoomStatus;
+import team.pickz.api.domain.draft.domain.type.RoomStatus;
 import team.pickz.api.domain.draft.domain.entity.DraftParticipant;
 import team.pickz.api.domain.draft.domain.entity.DraftPick;
 import team.pickz.api.domain.draft.domain.entity.DraftRoom;

--- a/api/src/main/java/team/pickz/api/domain/draft/application/DraftRoomService.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/DraftRoomService.java
@@ -6,13 +6,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.pickz.api.domain.draft.application.dto.request.DraftRoomStreamerRequest;
 import team.pickz.api.domain.draft.application.dto.request.RoomInitRequest;
-import team.pickz.api.domain.draft.application.dto.response.DraftRoomStreamerResponse;
-import team.pickz.api.domain.draft.application.dto.response.ParticipantResponse;
+import team.pickz.api.domain.draft.application.dto.response.*;
 import team.pickz.api.domain.draft.application.event.DraftRoomStartedEvent;
 import team.pickz.api.domain.draft.application.event.ParticipantJoinedEvent;
 import team.pickz.api.domain.draft.application.event.ParticipantUpdateEvent;
 import team.pickz.api.domain.draft.application.event.RoomStatusEvent;
-import team.pickz.api.domain.draft.application.dto.response.RoomInitResponse;
 import team.pickz.api.domain.draft.application.util.RandomNicknameGenerator;
 import team.pickz.api.domain.draft.application.util.RoomSequenceManager;
 import team.pickz.api.domain.draft.domain.repository.DraftRoomStreamerRepository;
@@ -93,10 +91,10 @@ public class DraftRoomService {
 
         for (DraftRoomStreamerRequest req : requests) {
             savePositionStreamers(roomId, req.teamSlot(), Position.TOP, req.top());
-            savePositionStreamers(roomId, req.teamSlot(), Position.JUG, req.jungle());
+            savePositionStreamers(roomId, req.teamSlot(), Position.JUG, req.jug());
             savePositionStreamers(roomId, req.teamSlot(), Position.MID, req.mid());
             savePositionStreamers(roomId, req.teamSlot(), Position.ADC, req.adc());
-            savePositionStreamers(roomId, req.teamSlot(), Position.SUP, req.support());
+            savePositionStreamers(roomId, req.teamSlot(), Position.SUP, req.sup());
             savePositionStreamers(roomId, req.teamSlot(), Position.COACH, req.coach());
         }
     }
@@ -139,7 +137,7 @@ public class DraftRoomService {
         DraftRoom room = draftRoomRepository.findByInviteCode(inviteCode)
                 .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 초대 코드입니다."));
 
-        if (room.getStatus() != RoomStatus.WAITING) {
+        if(room.getStatus() != RoomStatus.WAITING) {
             throw new IllegalStateException("이미 게임이 시작된 방입니다.");
         }
 
@@ -178,50 +176,6 @@ public class DraftRoomService {
                 .isHost(participant.isHost())
                 .build();
     }
-
-//    @Transactional
-//    public void configureAndStartRoom(Long roomId, String participantToken, RoomConfigureRequest request) {
-//        DraftRoom room = draftRoomRepository.findById(roomId)
-//                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 방입니다."));
-//
-//        DraftParticipant requestor = draftParticipantRepository.findByParticipantToken(participantToken)
-//                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 참여자입니다."));
-//
-//        if (!requestor.isHost()) {
-//            throw new IllegalArgumentException("방장만 드래프트를 시작할 수 있습니다.");
-//        }
-//
-//        if(!requestor.getRoomId().equals(roomId)) {
-//            throw new IllegalArgumentException("해당 방의 방장이 아닙니다.");
-//        }
-//
-//        room.updateSettings(request.teamCount(), request.teamSize());
-//
-//        List<DraftParticipant> participants = draftParticipantRepository.findAllByRoomId(roomId);
-//        if (participants.size() != room.getTeamCount()) {
-//            throw new IllegalStateException("설정된 팀 개수만큼 참여자가 모여야 시작할 수 있습니다.");
-//        }
-//
-//        room.start();
-//
-//        Collections.shuffle(participants);
-//        for (int i = 0; i < participants.size(); i++) {
-//            participants.get(i).assignTurnOrder(i);
-//        }
-//
-//        RoomStatusEvent event = RoomStatusEvent.builder()
-//                .code("SUCCESS")
-//                .roomStatus(room.getStatus())
-//                .redirectUrl("/drafts/" + roomId + "/play")
-//                .build();
-//
-//        applicationEventPublisher.publishEvent(
-//                DraftRoomStartedEvent.builder()
-//                        .roomId(roomId)
-//                        .payload(event)
-//                        .build()
-//        );
-//    }
 
     @Transactional
     public void selectCoach(Long roomId, String participantToken, String coachName, int targetTurnOrder) {
@@ -280,5 +234,94 @@ public class DraftRoomService {
                         .build()
         );
     }
+
+    @Transactional(readOnly = true)
+    public DraftPlayStateResponse getDraftPlayState(Long roomId) {
+        DraftRoom room = draftRoomRepository.findById(roomId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 방입니다."));
+
+        // 1. 참가자(감독) 정보 조회 및 정렬
+        List<DraftParticipant> participants = draftParticipantRepository.findAllByRoomId(roomId);
+
+        // 감독 선택을 완료한 참가자만 필터링 후 픽 순서(turnOrder)대로 정렬
+        List<DraftParticipant> coaches = participants.stream()
+                .filter(p -> p.getSelectedCoachName() != null)
+                .sorted(Comparator.comparing(p -> p.getTurnOrder() != null ? p.getTurnOrder() : 999))
+                .toList();
+
+        // "pickOrder": ["감독A", "감독B"...] 배열 추출
+        List<String> pickOrder = coaches.stream()
+                .map(DraftParticipant::getSelectedCoachName)
+                .toList();
+
+        // "coaches": [...] 객체 배열 추출
+        List<CoachResponse> coachResponses = coaches.stream()
+                .map(p -> new CoachResponse(
+                        p.getSelectedCoachName(),
+                        p.getNickname()
+                ))
+                .toList();
+
+        // 2. 스트리머 풀 조회 로직 재활용
+        List<DraftRoomStreamer> streamers = draftRoomStreamerRepository.findAllByRoomId(roomId);
+
+        DraftConfigResponse.StreamersByLine streamersByLine = new DraftConfigResponse.StreamersByLine(
+                extractByPosition(streamers, Position.TOP),
+                extractByPosition(streamers, Position.JUG),
+                extractByPosition(streamers, Position.MID),
+                extractByPosition(streamers, Position.ADC),
+                extractByPosition(streamers, Position.SUP),
+                extractByPosition(streamers, Position.COACH)
+        );
+
+        // 3. 최종 데이터 조립
+        DraftConfigResponse draftConfig = new DraftConfigResponse(pickOrder, coachResponses, streamersByLine);
+
+        return new DraftPlayStateResponse(room.getId(), room.getStatus(), draftConfig);
+    }
+
+    //    @Transactional
+//    public void configureAndStartRoom(Long roomId, String participantToken, RoomConfigureRequest request) {
+//        DraftRoom room = draftRoomRepository.findById(roomId)
+//                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 방입니다."));
+//
+//        DraftParticipant requestor = draftParticipantRepository.findByParticipantToken(participantToken)
+//                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 참여자입니다."));
+//
+//        if (!requestor.isHost()) {
+//            throw new IllegalArgumentException("방장만 드래프트를 시작할 수 있습니다.");
+//        }
+//
+//        if(!requestor.getRoomId().equals(roomId)) {
+//            throw new IllegalArgumentException("해당 방의 방장이 아닙니다.");
+//        }
+//
+//        room.updateSettings(request.teamCount(), request.teamSize());
+//
+//        List<DraftParticipant> participants = draftParticipantRepository.findAllByRoomId(roomId);
+//        if (participants.size() != room.getTeamCount()) {
+//            throw new IllegalStateException("설정된 팀 개수만큼 참여자가 모여야 시작할 수 있습니다.");
+//        }
+//
+//        room.start();
+//
+//        Collections.shuffle(participants);
+//        for (int i = 0; i < participants.size(); i++) {
+//            participants.get(i).assignTurnOrder(i);
+//        }
+//
+//        RoomStatusEvent event = RoomStatusEvent.builder()
+//                .code("SUCCESS")
+//                .roomStatus(room.getStatus())
+//                .redirectUrl("/drafts/" + roomId + "/play")
+//                .build();
+//
+//        applicationEventPublisher.publishEvent(
+//                DraftRoomStartedEvent.builder()
+//                        .roomId(roomId)
+//                        .payload(event)
+//                        .build()
+//        );
+//    }
 
 }

--- a/api/src/main/java/team/pickz/api/domain/draft/application/DraftRoomService.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/DraftRoomService.java
@@ -80,7 +80,7 @@ public class DraftRoomService {
 
     @Transactional
     public void saveDraftRoomStreamers(Long roomId, String participantToken, List<DraftRoomStreamerRequest> requests) {
-        DraftParticipant requestor = draftParticipantRepository.findByParticipantToken(participantToken)
+        DraftParticipant requestor = draftParticipantRepository.findByRoomIdAndParticipantToken(roomId, participantToken)
                 .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 참여자입니다."));
 
         if (!requestor.isHost()) {

--- a/api/src/main/java/team/pickz/api/domain/draft/application/DraftRoomService.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/DraftRoomService.java
@@ -4,25 +4,32 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import team.pickz.api.domain.draft.application.dto.request.DraftRoomStreamerRequest;
+import team.pickz.api.domain.draft.application.dto.request.RoomInitRequest;
+import team.pickz.api.domain.draft.application.dto.response.DraftRoomStreamerResponse;
 import team.pickz.api.domain.draft.application.dto.response.ParticipantResponse;
 import team.pickz.api.domain.draft.application.event.DraftRoomStartedEvent;
 import team.pickz.api.domain.draft.application.event.ParticipantJoinedEvent;
 import team.pickz.api.domain.draft.application.event.ParticipantUpdateEvent;
 import team.pickz.api.domain.draft.application.event.RoomStatusEvent;
-import team.pickz.api.domain.draft.application.dto.request.RoomConfigureRequest;
 import team.pickz.api.domain.draft.application.dto.response.RoomInitResponse;
 import team.pickz.api.domain.draft.application.util.RandomNicknameGenerator;
 import team.pickz.api.domain.draft.application.util.RoomSequenceManager;
-import team.pickz.api.domain.draft.domain.RoomStatus;
+import team.pickz.api.domain.draft.domain.repository.DraftRoomStreamerRepository;
+import team.pickz.api.domain.draft.domain.type.ParticipationType;
+import team.pickz.api.domain.draft.domain.type.Position;
+import team.pickz.api.domain.draft.domain.type.RoomStatus;
 import team.pickz.api.domain.draft.domain.entity.DraftParticipant;
 import team.pickz.api.domain.draft.domain.entity.DraftRoom;
+import team.pickz.api.domain.draft.domain.entity.DraftRoomStreamer;
 import team.pickz.api.domain.draft.domain.repository.DraftParticipantRepository;
 import team.pickz.api.domain.draft.domain.repository.DraftRoomRepository;
-import team.pickz.api.domain.member.domain.Member;
 import team.pickz.api.domain.member.domain.MemberRepository;
 
-import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -31,18 +38,30 @@ public class DraftRoomService {
     private final MemberRepository memberRepository;
     private final DraftRoomRepository draftRoomRepository;
     private final DraftParticipantRepository draftParticipantRepository;
+    private final DraftRoomStreamerRepository draftRoomStreamerRepository;
     private final RoomSequenceManager roomSequenceManager;
     private final ApplicationEventPublisher applicationEventPublisher;
 
     @Transactional
-    public RoomInitResponse initRoom(/**Long hostMemberId,**/ String mode, String ruleName) {
+    public RoomInitResponse initRoom(/**Long hostMemberId,**/RoomInitRequest request) {
         //Member member = memberRepository.findByMemberId(hostMemberId);
 
-        DraftRoom room = DraftRoom.builder()
-                .draftMode(mode)
-                .draftRuleType(ruleName)
-                .build();
+        int teamCount = request.teamCount() != null ? request.teamCount() : 5;
+        int teamSize = request.teamSize() != null ? request.teamSize() : 5;
 
+        if ("2026_ZANATDAE".equals(request.preset())) {
+            teamCount = 4;
+            teamSize = 5;
+        }
+
+        DraftRoom room = DraftRoom.builder()
+                .title(request.title())
+                .draftMode(request.draftMode())
+                .participationType(request.participationType())
+                .preset(request.preset())
+                .teamCount(teamCount)
+                .teamSize(teamSize)
+                .build();
         draftRoomRepository.save(room);
 
         DraftParticipant host = DraftParticipant.builder()
@@ -51,7 +70,6 @@ public class DraftRoomService {
                 //.nickname(member.getNickname())
                 .isHost(true)
                 .build();
-
         draftParticipantRepository.save(host);
 
         return RoomInitResponse.builder()
@@ -60,6 +78,60 @@ public class DraftRoomService {
                 .participantToken(host.getParticipantToken())
                 .isHost(true)
                 .build();
+    }
+
+    @Transactional
+    public void saveDraftRoomStreamers(Long roomId, String participantToken, List<DraftRoomStreamerRequest> requests) {
+        DraftParticipant requestor = draftParticipantRepository.findByParticipantToken(participantToken)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 참여자입니다."));
+
+        if (!requestor.isHost()) {
+            throw new IllegalArgumentException("방장만 스트리머 풀을 설정할 수 있습니다.");
+        }
+
+        draftRoomStreamerRepository.deleteAllByRoomId(roomId);
+
+        for (DraftRoomStreamerRequest req : requests) {
+            savePositionStreamers(roomId, req.teamSlot(), Position.TOP, req.top());
+            savePositionStreamers(roomId, req.teamSlot(), Position.JUG, req.jungle());
+            savePositionStreamers(roomId, req.teamSlot(), Position.MID, req.mid());
+            savePositionStreamers(roomId, req.teamSlot(), Position.ADC, req.adc());
+            savePositionStreamers(roomId, req.teamSlot(), Position.SUP, req.support());
+            savePositionStreamers(roomId, req.teamSlot(), Position.COACH, req.coach());
+        }
+    }
+
+    private void savePositionStreamers(Long roomId, int teamSlot, Position position, String name) {
+        if(name == null || name.isBlank()) return;
+        DraftRoomStreamer streamer = DraftRoomStreamer.builder()
+                .roomId(roomId)
+                .teamSlot(teamSlot)
+                .position(position)
+                .streamerName(name)
+                .build();
+        draftRoomStreamerRepository.save(streamer);
+    }
+
+    @Transactional(readOnly = true)
+    public DraftRoomStreamerResponse getDraftRoomStreamers(Long roomId) {
+        List<DraftRoomStreamer> streamers = draftRoomStreamerRepository.findAllByRoomId(roomId);
+
+        List<String> top = extractByPosition(streamers, Position.TOP);
+        List<String> jungle = extractByPosition(streamers, Position.JUG);
+        List<String> mid = extractByPosition(streamers, Position.MID);
+        List<String> adc = extractByPosition(streamers, Position.ADC);
+        List<String> support = extractByPosition(streamers, Position.SUP);
+        List<String> coach = extractByPosition(streamers, Position.COACH);
+
+        return new DraftRoomStreamerResponse(top, jungle, mid, adc, support, coach);
+    }
+
+    private List<String> extractByPosition(List<DraftRoomStreamer> streamers, Position position) {
+        return streamers.stream()
+                .filter(s -> s.getPosition() == position)
+                .sorted(Comparator.comparingInt(DraftRoomStreamer::getTeamSlot))
+                .map(DraftRoomStreamer::getStreamerName)
+                .toList();
     }
 
     @Transactional
@@ -107,8 +179,69 @@ public class DraftRoomService {
                 .build();
     }
 
+//    @Transactional
+//    public void configureAndStartRoom(Long roomId, String participantToken, RoomConfigureRequest request) {
+//        DraftRoom room = draftRoomRepository.findById(roomId)
+//                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 방입니다."));
+//
+//        DraftParticipant requestor = draftParticipantRepository.findByParticipantToken(participantToken)
+//                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 참여자입니다."));
+//
+//        if (!requestor.isHost()) {
+//            throw new IllegalArgumentException("방장만 드래프트를 시작할 수 있습니다.");
+//        }
+//
+//        if(!requestor.getRoomId().equals(roomId)) {
+//            throw new IllegalArgumentException("해당 방의 방장이 아닙니다.");
+//        }
+//
+//        room.updateSettings(request.teamCount(), request.teamSize());
+//
+//        List<DraftParticipant> participants = draftParticipantRepository.findAllByRoomId(roomId);
+//        if (participants.size() != room.getTeamCount()) {
+//            throw new IllegalStateException("설정된 팀 개수만큼 참여자가 모여야 시작할 수 있습니다.");
+//        }
+//
+//        room.start();
+//
+//        Collections.shuffle(participants);
+//        for (int i = 0; i < participants.size(); i++) {
+//            participants.get(i).assignTurnOrder(i);
+//        }
+//
+//        RoomStatusEvent event = RoomStatusEvent.builder()
+//                .code("SUCCESS")
+//                .roomStatus(room.getStatus())
+//                .redirectUrl("/drafts/" + roomId + "/play")
+//                .build();
+//
+//        applicationEventPublisher.publishEvent(
+//                DraftRoomStartedEvent.builder()
+//                        .roomId(roomId)
+//                        .payload(event)
+//                        .build()
+//        );
+//    }
+
     @Transactional
-    public void configureAndStartRoom(Long roomId, String participantToken, RoomConfigureRequest request) {
+    public void selectCoach(Long roomId, String participantToken, String coachName, int targetTurnOrder) {
+        DraftParticipant participant = draftParticipantRepository.findByParticipantToken(participantToken)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 참여자입니다."));
+
+        // 동시성 처리 고려: 이미 누군가 해당 감독/순서를 골랐는지 검증
+        boolean isAlreadySelected = draftParticipantRepository.existsByRoomIdAndSelectedCoachName(roomId, coachName);
+        if (isAlreadySelected) {
+            throw new IllegalStateException("이미 다른 참가자가 선택한 감독입니다.");
+        }
+
+        participant.selectCoach(coachName, targetTurnOrder);
+
+        // WebSocket 이벤트 발행 로직 (선택사항)
+        // applicationEventPublisher.publishEvent(...);
+    }
+
+    @Transactional
+    public void startDraft(Long roomId, String participantToken) {
         DraftRoom room = draftRoomRepository.findById(roomId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 방입니다."));
 
@@ -119,23 +252,20 @@ public class DraftRoomService {
             throw new IllegalArgumentException("방장만 드래프트를 시작할 수 있습니다.");
         }
 
-        if(!requestor.getRoomId().equals(roomId)) {
-            throw new IllegalArgumentException("해당 방의 방장이 아닙니다.");
-        }
-
-        room.updateSettings(request.teamCount(), request.teamSize());
-
         List<DraftParticipant> participants = draftParticipantRepository.findAllByRoomId(roomId);
-        if (participants.size() != room.getTeamCount()) {
-            throw new IllegalStateException("설정된 팀 개수만큼 참여자가 모여야 시작할 수 있습니다.");
+
+        // 혼자하기 모드가 아닐 경우, 참가자들이 모두 감독 선택을 완료했는지 검증
+        if (room.getParticipationType() == ParticipationType.TOGETHER) {
+            long selectedCount = participants.stream().filter(p -> p.getSelectedCoachName() != null).count();
+            if (selectedCount != room.getTeamCount()) {
+                throw new IllegalStateException("모든 참가자가 감독(팀)을 선택해야 시작할 수 있습니다.");
+            }
         }
 
         room.start();
 
-        Collections.shuffle(participants);
-        for (int i = 0; i < participants.size(); i++) {
-            participants.get(i).assignTurnOrder(i);
-        }
+        // 기존의 Collections.shuffle(participants)는 삭제합니다.
+        // -> 참가자가 직접 감독을 선택하면서 픽 순서(turnOrder)가 결정되었기 때문입니다.
 
         RoomStatusEvent event = RoomStatusEvent.builder()
                 .code("SUCCESS")

--- a/api/src/main/java/team/pickz/api/domain/draft/application/DraftRoomService.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/DraftRoomService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import team.pickz.api.domain.draft.application.dto.StreamerInfo;
 import team.pickz.api.domain.draft.application.dto.request.DraftRoomStreamerRequest;
 import team.pickz.api.domain.draft.application.dto.request.RoomInitRequest;
 import team.pickz.api.domain.draft.application.dto.response.*;
@@ -99,13 +100,15 @@ public class DraftRoomService {
         }
     }
 
-    private void savePositionStreamers(Long roomId, int teamSlot, Position position, String name) {
-        if(name == null || name.isBlank()) return;
+    private void savePositionStreamers(Long roomId, int teamSlot, Position position, StreamerInfo info) {
+        if (info == null || info.name() == null || info.name().isBlank()) return;
+
         DraftRoomStreamer streamer = DraftRoomStreamer.builder()
                 .roomId(roomId)
                 .teamSlot(teamSlot)
                 .position(position)
-                .streamerName(name)
+                .streamerName(info.name())
+                .imageUrl(info.imageUrl())
                 .build();
         draftRoomStreamerRepository.save(streamer);
     }
@@ -114,21 +117,21 @@ public class DraftRoomService {
     public DraftRoomStreamerResponse getDraftRoomStreamers(Long roomId) {
         List<DraftRoomStreamer> streamers = draftRoomStreamerRepository.findAllByRoomId(roomId);
 
-        List<String> top = extractByPosition(streamers, Position.TOP);
-        List<String> jungle = extractByPosition(streamers, Position.JUG);
-        List<String> mid = extractByPosition(streamers, Position.MID);
-        List<String> adc = extractByPosition(streamers, Position.ADC);
-        List<String> support = extractByPosition(streamers, Position.SUP);
-        List<String> coach = extractByPosition(streamers, Position.COACH);
+        List<StreamerInfo> top = extractByPosition(streamers, Position.TOP);
+        List<StreamerInfo> jungle = extractByPosition(streamers, Position.JUG);
+        List<StreamerInfo> mid = extractByPosition(streamers, Position.MID);
+        List<StreamerInfo> adc = extractByPosition(streamers, Position.ADC);
+        List<StreamerInfo> support = extractByPosition(streamers, Position.SUP);
+        List<StreamerInfo> coach = extractByPosition(streamers, Position.COACH);
 
         return new DraftRoomStreamerResponse(top, jungle, mid, adc, support, coach);
     }
 
-    private List<String> extractByPosition(List<DraftRoomStreamer> streamers, Position position) {
+    private List<StreamerInfo> extractByPosition(List<DraftRoomStreamer> streamers, Position position) {
         return streamers.stream()
                 .filter(s -> s.getPosition() == position)
                 .sorted(Comparator.comparingInt(DraftRoomStreamer::getTeamSlot))
-                .map(DraftRoomStreamer::getStreamerName)
+                .map(s -> new StreamerInfo(s.getStreamerName(), s.getImageUrl()))
                 .toList();
     }
 

--- a/api/src/main/java/team/pickz/api/domain/draft/application/dto/StreamerInfo.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/dto/StreamerInfo.java
@@ -1,0 +1,6 @@
+package team.pickz.api.domain.draft.application.dto;
+
+public record StreamerInfo(
+        String name,
+        String imageUrl
+) {}

--- a/api/src/main/java/team/pickz/api/domain/draft/application/dto/request/CoachSelectionRequest.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/dto/request/CoachSelectionRequest.java
@@ -1,0 +1,15 @@
+package team.pickz.api.domain.draft.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CoachSelectionRequest(
+
+        @NotBlank(message = "감독 이름은 필수입니다.")
+        String coachName,
+
+        @NotNull(message = "픽 순서는 필수입니다.")
+        Integer targetTurnOrder
+
+) {
+}

--- a/api/src/main/java/team/pickz/api/domain/draft/application/dto/request/DraftRoomStreamerRequest.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/dto/request/DraftRoomStreamerRequest.java
@@ -8,13 +8,13 @@ public record DraftRoomStreamerRequest(
 
         String top,
 
-        String jungle,
+        String jug,
 
         String mid,
 
         String adc,
 
-        String support,
+        String sup,
 
         String coach
 

--- a/api/src/main/java/team/pickz/api/domain/draft/application/dto/request/DraftRoomStreamerRequest.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/dto/request/DraftRoomStreamerRequest.java
@@ -1,0 +1,22 @@
+package team.pickz.api.domain.draft.application.dto.request;
+
+import java.util.List;
+
+public record DraftRoomStreamerRequest(
+
+        int teamSlot,
+
+        String top,
+
+        String jungle,
+
+        String mid,
+
+        String adc,
+
+        String support,
+
+        String coach
+
+) {
+}

--- a/api/src/main/java/team/pickz/api/domain/draft/application/dto/request/DraftRoomStreamerRequest.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/dto/request/DraftRoomStreamerRequest.java
@@ -1,22 +1,22 @@
 package team.pickz.api.domain.draft.application.dto.request;
 
-import java.util.List;
+import team.pickz.api.domain.draft.application.dto.StreamerInfo;
 
 public record DraftRoomStreamerRequest(
 
         int teamSlot,
 
-        String top,
+        StreamerInfo top,
 
-        String jug,
+        StreamerInfo jug,
 
-        String mid,
+        StreamerInfo mid,
 
-        String adc,
+        StreamerInfo adc,
 
-        String sup,
+        StreamerInfo sup,
 
-        String coach
+        StreamerInfo coach
 
 ) {
 }

--- a/api/src/main/java/team/pickz/api/domain/draft/application/dto/request/RoomInitRequest.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/dto/request/RoomInitRequest.java
@@ -1,14 +1,24 @@
 package team.pickz.api.domain.draft.application.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import team.pickz.api.domain.draft.domain.type.DraftMode;
+import team.pickz.api.domain.draft.domain.type.ParticipationType;
 
 public record RoomInitRequest(
 
-        @NotBlank(message = "참여 모드는 필수 입니다.")
-        String mode,
+        String title,
 
-        @NotBlank(message = "드래프트 룰 이름은 필수입니다.")
-        String ruleName
+        @NotNull(message = "드래프트 방식은 필수입니다.")
+        DraftMode draftMode,
+
+        @NotNull(message = "참여 방식은 필수입니다.")
+        ParticipationType participationType,
+
+        String preset,
+
+        Integer teamCount,
+
+        Integer teamSize
 
 ) {
 }

--- a/api/src/main/java/team/pickz/api/domain/draft/application/dto/response/ChatMessageResponse.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/dto/response/ChatMessageResponse.java
@@ -3,7 +3,7 @@ package team.pickz.api.domain.draft.application.dto.response;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
-import team.pickz.api.domain.draft.domain.MessageType;
+import team.pickz.api.domain.draft.domain.type.MessageType;
 
 @Builder
 public record ChatMessageResponse(

--- a/api/src/main/java/team/pickz/api/domain/draft/application/dto/response/CoachResponse.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/dto/response/CoachResponse.java
@@ -1,0 +1,11 @@
+package team.pickz.api.domain.draft.application.dto.response;
+
+public record CoachResponse(
+
+        String nickname,
+
+        String participantNickname
+
+) {
+
+}

--- a/api/src/main/java/team/pickz/api/domain/draft/application/dto/response/DraftConfigResponse.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/dto/response/DraftConfigResponse.java
@@ -1,0 +1,23 @@
+package team.pickz.api.domain.draft.application.dto.response;
+
+import java.util.List;
+
+public record DraftConfigResponse(
+
+        List<String> pickOrder,
+
+        List<CoachResponse> coaches,
+
+        StreamersByLine streamersByLine
+) {
+
+    public record StreamersByLine(
+            List<String> top,
+            List<String> jungle,
+            List<String> mid,
+            List<String> adc,
+            List<String> support,
+            List<String> coach
+    ) {}
+
+}

--- a/api/src/main/java/team/pickz/api/domain/draft/application/dto/response/DraftConfigResponse.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/dto/response/DraftConfigResponse.java
@@ -1,5 +1,7 @@
 package team.pickz.api.domain.draft.application.dto.response;
 
+import team.pickz.api.domain.draft.application.dto.StreamerInfo;
+
 import java.util.List;
 
 public record DraftConfigResponse(
@@ -12,12 +14,12 @@ public record DraftConfigResponse(
 ) {
 
     public record StreamersByLine(
-            List<String> top,
-            List<String> jungle,
-            List<String> mid,
-            List<String> adc,
-            List<String> support,
-            List<String> coach
+            List<StreamerInfo> top,
+            List<StreamerInfo> jungle,
+            List<StreamerInfo> mid,
+            List<StreamerInfo> adc,
+            List<StreamerInfo> support,
+            List<StreamerInfo> coach
     ) {}
 
 }

--- a/api/src/main/java/team/pickz/api/domain/draft/application/dto/response/DraftPlayStateResponse.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/dto/response/DraftPlayStateResponse.java
@@ -1,0 +1,15 @@
+package team.pickz.api.domain.draft.application.dto.response;
+
+import team.pickz.api.domain.draft.domain.type.RoomStatus;
+
+public record DraftPlayStateResponse(
+
+        Long roomId,
+
+        RoomStatus roomStatus,
+
+        DraftConfigResponse draftConfig
+
+) {
+
+}

--- a/api/src/main/java/team/pickz/api/domain/draft/application/dto/response/DraftRoomStreamerResponse.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/dto/response/DraftRoomStreamerResponse.java
@@ -1,0 +1,20 @@
+package team.pickz.api.domain.draft.application.dto.response;
+
+import java.util.List;
+
+public record DraftRoomStreamerResponse(
+
+        List<String> top,
+
+        List<String> jug,
+
+        List<String> mid,
+
+        List<String> adc,
+
+        List<String> sup,
+
+        List<String> coach
+
+) {
+}

--- a/api/src/main/java/team/pickz/api/domain/draft/application/dto/response/DraftRoomStreamerResponse.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/dto/response/DraftRoomStreamerResponse.java
@@ -1,20 +1,22 @@
 package team.pickz.api.domain.draft.application.dto.response;
 
+import team.pickz.api.domain.draft.application.dto.StreamerInfo;
+
 import java.util.List;
 
 public record DraftRoomStreamerResponse(
 
-        List<String> top,
+        List<StreamerInfo> top,
 
-        List<String> jug,
+        List<StreamerInfo> jug,
 
-        List<String> mid,
+        List<StreamerInfo> mid,
 
-        List<String> adc,
+        List<StreamerInfo> adc,
 
-        List<String> sup,
+        List<StreamerInfo> sup,
 
-        List<String> coach
+        List<StreamerInfo> coach
 
 ) {
 }

--- a/api/src/main/java/team/pickz/api/domain/draft/application/dto/response/PickResultResponse.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/dto/response/PickResultResponse.java
@@ -13,6 +13,10 @@ public record PickResultResponse(
 
         String pickedStreamerId,
 
+        String pickedStreamerName,
+
+        String pickedStreamerImageUrl,
+
         String nextTurnNickname,
 
         boolean isDraftDone

--- a/api/src/main/java/team/pickz/api/domain/draft/application/event/RoomStatusEvent.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/event/RoomStatusEvent.java
@@ -1,7 +1,7 @@
 package team.pickz.api.domain.draft.application.event;
 
 import lombok.Builder;
-import team.pickz.api.domain.draft.domain.RoomStatus;
+import team.pickz.api.domain.draft.domain.type.RoomStatus;
 
 @Builder
 public record RoomStatusEvent(

--- a/api/src/main/java/team/pickz/api/domain/draft/domain/entity/DraftParticipant.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/domain/entity/DraftParticipant.java
@@ -31,6 +31,8 @@ public class DraftParticipant {
 
     private Integer turnOrder;
 
+    private String selectedCoachName;
+
     @Builder
     public DraftParticipant(Long roomId, Long memberId, String nickname, boolean isHost) {
         this.roomId = roomId;
@@ -41,6 +43,11 @@ public class DraftParticipant {
     }
 
     public void assignTurnOrder(int turnOrder) {
+        this.turnOrder = turnOrder;
+    }
+
+    public void selectCoach(String coachName, int turnOrder) {
+        this.selectedCoachName = coachName;
         this.turnOrder = turnOrder;
     }
 

--- a/api/src/main/java/team/pickz/api/domain/draft/domain/entity/DraftRoom.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/domain/entity/DraftRoom.java
@@ -5,7 +5,9 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import team.pickz.api.domain.draft.domain.RoomStatus;
+import team.pickz.api.domain.draft.domain.type.DraftMode;
+import team.pickz.api.domain.draft.domain.type.ParticipationType;
+import team.pickz.api.domain.draft.domain.type.RoomStatus;
 
 import java.util.UUID;
 
@@ -18,15 +20,21 @@ public class DraftRoom {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    private String title;
+
     @Column(nullable = false, unique = true)
     private String inviteCode;
 
     @Enumerated(EnumType.STRING)
     private RoomStatus status;
 
-    private String draftMode;
+    @Enumerated(EnumType.STRING)
+    private DraftMode draftMode;
 
-    private String draftRuleType;
+    @Enumerated(EnumType.STRING)
+    private ParticipationType participationType;
+
+    private String preset;
 
     private int teamCount;
 
@@ -35,11 +43,16 @@ public class DraftRoom {
     private int currentPickCount;
 
     @Builder
-    public DraftRoom(String draftMode, String draftRuleType, int teamCount, int teamSize) {
+    public DraftRoom(String title, DraftMode draftMode, ParticipationType participationType, String preset, int teamCount, int teamSize) {
+        if (participationType == ParticipationType.TOGETHER && (title == null || title.isBlank())) {
+            throw new IllegalArgumentException("같이하기 모드에서는 방 제목이 필수입니다.");
+        }
+        this.title = title;
         this.inviteCode = UUID.randomUUID().toString().substring(0, 8);
         this.status = RoomStatus.WAITING;
         this.draftMode = draftMode;
-        this.draftRuleType = draftRuleType;
+        this.participationType = participationType;
+        this.preset = preset;
         this.teamCount = teamCount;
         this.teamSize = teamSize;
         this.currentPickCount = 0;
@@ -59,9 +72,9 @@ public class DraftRoom {
         }
     }
 
-    public void updateSettings(int teamCount, int teamSize) {
-        this.teamCount = teamCount;
-        this.teamSize = teamSize;
-    }
+//    public void updateSettings(int teamCount, int teamSize) {
+//        this.teamCount = teamCount;
+//        this.teamSize = teamSize;
+//    }
 
 }

--- a/api/src/main/java/team/pickz/api/domain/draft/domain/entity/DraftRoomStreamer.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/domain/entity/DraftRoomStreamer.java
@@ -1,0 +1,34 @@
+package team.pickz.api.domain.draft.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import team.pickz.api.domain.draft.domain.type.Position;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class DraftRoomStreamer {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "room_id", nullable = false)
+    private Long roomId;
+
+    private String streamerName;
+
+    @Enumerated(EnumType.STRING)
+    private Position position;
+
+    private int teamSlot;
+
+    @Builder
+    public DraftRoomStreamer(Long roomId, String streamerName, Position position, int teamSlot) {
+        this.roomId = roomId;
+        this.streamerName = streamerName;
+        this.position = position;
+        this.teamSlot = teamSlot;
+    }
+
+}

--- a/api/src/main/java/team/pickz/api/domain/draft/domain/entity/DraftRoomStreamer.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/domain/entity/DraftRoomStreamer.java
@@ -18,15 +18,18 @@ public class DraftRoomStreamer {
 
     private String streamerName;
 
+    private String imageUrl;
+
     @Enumerated(EnumType.STRING)
     private Position position;
 
     private int teamSlot;
 
     @Builder
-    public DraftRoomStreamer(Long roomId, String streamerName, Position position, int teamSlot) {
+    public DraftRoomStreamer(Long roomId, String streamerName, String imageUrl, Position position, int teamSlot) {
         this.roomId = roomId;
         this.streamerName = streamerName;
+        this.imageUrl = imageUrl;
         this.position = position;
         this.teamSlot = teamSlot;
     }

--- a/api/src/main/java/team/pickz/api/domain/draft/domain/repository/DraftParticipantRepository.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/domain/repository/DraftParticipantRepository.java
@@ -7,13 +7,15 @@ import java.util.Optional;
 
 public interface DraftParticipantRepository {
 
-    DraftParticipant save(DraftParticipant draftParticipant);
+    List<DraftParticipant> findAllByRoomId(Long roomId);
 
-    Optional<DraftParticipant> findByParticipantToken(String participantToken);
+    DraftParticipant save(DraftParticipant draftParticipant);
 
     List<DraftParticipant> findAllByRoomIdOrderByTurnOrderAsc(Long roomId);
 
-    List<DraftParticipant> findAllByRoomId(Long roomId);
+    boolean existsByRoomIdAndSelectedCoachName(Long roomId, String coachName);
+
+    Optional<DraftParticipant> findByParticipantToken(String participantToken);
 
     Optional<DraftParticipant> findByRoomIdAndParticipantToken(Long roomId, String participantToken);
 

--- a/api/src/main/java/team/pickz/api/domain/draft/domain/repository/DraftPickRepository.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/domain/repository/DraftPickRepository.java
@@ -4,8 +4,8 @@ import team.pickz.api.domain.draft.domain.entity.DraftPick;
 
 public interface DraftPickRepository {
 
-    Boolean existsByRoomIdAndStreamerId(Long roomId, String streamerId);
-
     void save(DraftPick draftPick);
+
+    Boolean existsByRoomIdAndStreamerId(Long roomId, String streamerId);
 
 }

--- a/api/src/main/java/team/pickz/api/domain/draft/domain/repository/DraftRoomStreamerRepository.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/domain/repository/DraftRoomStreamerRepository.java
@@ -3,6 +3,7 @@ package team.pickz.api.domain.draft.domain.repository;
 import team.pickz.api.domain.draft.domain.entity.DraftRoomStreamer;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface DraftRoomStreamerRepository {
 
@@ -11,5 +12,7 @@ public interface DraftRoomStreamerRepository {
     DraftRoomStreamer save(DraftRoomStreamer streamer);
 
     List<DraftRoomStreamer> findAllByRoomId(Long roomId);
+
+    Optional<DraftRoomStreamer> findByRoomIdAndStreamerName(Long roomId, String streamerId);
 
 }

--- a/api/src/main/java/team/pickz/api/domain/draft/domain/repository/DraftRoomStreamerRepository.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/domain/repository/DraftRoomStreamerRepository.java
@@ -1,0 +1,15 @@
+package team.pickz.api.domain.draft.domain.repository;
+
+import team.pickz.api.domain.draft.domain.entity.DraftRoomStreamer;
+
+import java.util.List;
+
+public interface DraftRoomStreamerRepository {
+
+    void deleteAllByRoomId(Long roomId);
+
+    DraftRoomStreamer save(DraftRoomStreamer streamer);
+
+    List<DraftRoomStreamer> findAllByRoomId(Long roomId);
+
+}

--- a/api/src/main/java/team/pickz/api/domain/draft/domain/type/DraftMode.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/domain/type/DraftMode.java
@@ -1,0 +1,6 @@
+package team.pickz.api.domain.draft.domain.type;
+
+public enum DraftMode {
+    SNAKE,
+    AUCTION
+}

--- a/api/src/main/java/team/pickz/api/domain/draft/domain/type/MessageType.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/domain/type/MessageType.java
@@ -1,4 +1,4 @@
-package team.pickz.api.domain.draft.domain;
+package team.pickz.api.domain.draft.domain.type;
 
 public enum MessageType {
     CHAT,

--- a/api/src/main/java/team/pickz/api/domain/draft/domain/type/ParticipationType.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/domain/type/ParticipationType.java
@@ -1,0 +1,6 @@
+package team.pickz.api.domain.draft.domain.type;
+
+public enum ParticipationType {
+    SOLO,
+    TOGETHER
+}

--- a/api/src/main/java/team/pickz/api/domain/draft/domain/type/Position.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/domain/type/Position.java
@@ -1,0 +1,10 @@
+package team.pickz.api.domain.draft.domain.type;
+
+public enum Position {
+    TOP,
+    JUG,
+    MID,
+    ADC,
+    SUP,
+    COACH
+}

--- a/api/src/main/java/team/pickz/api/domain/draft/domain/type/RoomStatus.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/domain/type/RoomStatus.java
@@ -1,4 +1,4 @@
-package team.pickz.api.domain.draft.domain;
+package team.pickz.api.domain.draft.domain.type;
 
 public enum RoomStatus {
     WAITING,

--- a/api/src/main/java/team/pickz/api/domain/draft/infrastructure/DraftParticipantJpaRepository.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/infrastructure/DraftParticipantJpaRepository.java
@@ -10,9 +10,11 @@ public interface DraftParticipantJpaRepository extends JpaRepository<DraftPartic
 
     List<DraftParticipant> findAllByRoomId(Long roomId);
 
-    Optional<DraftParticipant> findByParticipantToken(String participantToken);
-
     List<DraftParticipant> findAllByRoomIdOrderByTurnOrderAsc(Long roomId);
+
+    boolean existsByRoomIdAndSelectedCoachName(Long roomId, String coachName);
+
+    Optional<DraftParticipant> findByParticipantToken(String participantToken);
 
     Optional<DraftParticipant> findByRoomIdAndParticipantToken(Long roomId, String participantToken);
 

--- a/api/src/main/java/team/pickz/api/domain/draft/infrastructure/DraftParticipantRepositoryImpl.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/infrastructure/DraftParticipantRepositoryImpl.java
@@ -8,8 +8,8 @@ import team.pickz.api.domain.draft.domain.repository.DraftParticipantRepository;
 import java.util.List;
 import java.util.Optional;
 
-@Repository
 @RequiredArgsConstructor
+@Repository
 public class DraftParticipantRepositoryImpl implements DraftParticipantRepository {
 
     private final DraftParticipantJpaRepository draftParticipantJpaRepository;
@@ -27,6 +27,11 @@ public class DraftParticipantRepositoryImpl implements DraftParticipantRepositor
     @Override
     public List<DraftParticipant> findAllByRoomIdOrderByTurnOrderAsc(Long roomId) {
         return draftParticipantJpaRepository.findAllByRoomIdOrderByTurnOrderAsc(roomId);
+    }
+
+    @Override
+    public boolean existsByRoomIdAndSelectedCoachName(Long roomId, String coachName) {
+        return draftParticipantJpaRepository.existsByRoomIdAndSelectedCoachName(roomId, coachName);
     }
 
     @Override

--- a/api/src/main/java/team/pickz/api/domain/draft/infrastructure/DraftPickRepositoryImpl.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/infrastructure/DraftPickRepositoryImpl.java
@@ -5,8 +5,8 @@ import org.springframework.stereotype.Repository;
 import team.pickz.api.domain.draft.domain.entity.DraftPick;
 import team.pickz.api.domain.draft.domain.repository.DraftPickRepository;
 
-@Repository
 @RequiredArgsConstructor
+@Repository
 public class DraftPickRepositoryImpl implements DraftPickRepository {
 
     private final DraftPickJpaRepository draftPickJpaRepository;

--- a/api/src/main/java/team/pickz/api/domain/draft/infrastructure/DraftRoomRepositoryImpl.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/infrastructure/DraftRoomRepositoryImpl.java
@@ -7,8 +7,8 @@ import team.pickz.api.domain.draft.domain.repository.DraftRoomRepository;
 
 import java.util.Optional;
 
-@Repository
 @RequiredArgsConstructor
+@Repository
 public class DraftRoomRepositoryImpl implements DraftRoomRepository {
 
     private final DraftRoomJpaRepository draftRoomJpaRepository;

--- a/api/src/main/java/team/pickz/api/domain/draft/infrastructure/DraftRoomStreamerJpaRepository.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/infrastructure/DraftRoomStreamerJpaRepository.java
@@ -1,0 +1,14 @@
+package team.pickz.api.domain.draft.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.pickz.api.domain.draft.domain.entity.DraftRoomStreamer;
+
+import java.util.List;
+
+public interface DraftRoomStreamerJpaRepository extends JpaRepository<DraftRoomStreamer, Long> {
+
+    void deleteAllByRoomId(Long roomId);
+
+    List<DraftRoomStreamer> findAllByRoomId(Long roomId);
+
+}

--- a/api/src/main/java/team/pickz/api/domain/draft/infrastructure/DraftRoomStreamerJpaRepository.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/infrastructure/DraftRoomStreamerJpaRepository.java
@@ -4,11 +4,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import team.pickz.api.domain.draft.domain.entity.DraftRoomStreamer;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface DraftRoomStreamerJpaRepository extends JpaRepository<DraftRoomStreamer, Long> {
 
     void deleteAllByRoomId(Long roomId);
 
     List<DraftRoomStreamer> findAllByRoomId(Long roomId);
+
+    Optional<DraftRoomStreamer> findByRoomIdAndStreamerName(Long roomId, String streamerId);
 
 }

--- a/api/src/main/java/team/pickz/api/domain/draft/infrastructure/DraftRoomStreamerRepositoryImpl.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/infrastructure/DraftRoomStreamerRepositoryImpl.java
@@ -6,6 +6,7 @@ import team.pickz.api.domain.draft.domain.entity.DraftRoomStreamer;
 import team.pickz.api.domain.draft.domain.repository.DraftRoomStreamerRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Repository
@@ -26,6 +27,11 @@ public class DraftRoomStreamerRepositoryImpl implements DraftRoomStreamerReposit
     @Override
     public List<DraftRoomStreamer> findAllByRoomId(Long roomId) {
         return draftRoomStreamerJpaRepository.findAllByRoomId(roomId);
+    }
+
+    @Override
+    public Optional<DraftRoomStreamer> findByRoomIdAndStreamerName(Long roomId, String streamerId) {
+        return draftRoomStreamerJpaRepository.findByRoomIdAndStreamerName(roomId, streamerId);
     }
 
 }

--- a/api/src/main/java/team/pickz/api/domain/draft/infrastructure/DraftRoomStreamerRepositoryImpl.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/infrastructure/DraftRoomStreamerRepositoryImpl.java
@@ -1,0 +1,31 @@
+package team.pickz.api.domain.draft.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import team.pickz.api.domain.draft.domain.entity.DraftRoomStreamer;
+import team.pickz.api.domain.draft.domain.repository.DraftRoomStreamerRepository;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Repository
+public class DraftRoomStreamerRepositoryImpl implements DraftRoomStreamerRepository {
+
+    private final DraftRoomStreamerJpaRepository draftRoomStreamerJpaRepository;
+
+    @Override
+    public void deleteAllByRoomId(Long roomId) {
+        draftRoomStreamerJpaRepository.deleteAllByRoomId(roomId);
+    }
+
+    @Override
+    public DraftRoomStreamer save(DraftRoomStreamer streamer) {
+        return draftRoomStreamerJpaRepository.save(streamer);
+    }
+
+    @Override
+    public List<DraftRoomStreamer> findAllByRoomId(Long roomId) {
+        return draftRoomStreamerJpaRepository.findAllByRoomId(roomId);
+    }
+
+}

--- a/api/src/main/java/team/pickz/api/domain/draft/presentation/DraftRoomController.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/presentation/DraftRoomController.java
@@ -11,6 +11,7 @@ import team.pickz.api.domain.draft.application.dto.request.CoachSelectionRequest
 import team.pickz.api.domain.draft.application.dto.request.DraftRoomStreamerRequest;
 import team.pickz.api.domain.draft.application.dto.request.RoomConfigureRequest;
 import team.pickz.api.domain.draft.application.dto.request.RoomInitRequest;
+import team.pickz.api.domain.draft.application.dto.response.DraftPlayStateResponse;
 import team.pickz.api.domain.draft.application.dto.response.DraftRoomStreamerResponse;
 import team.pickz.api.domain.draft.application.dto.response.ParticipantResponse;
 import team.pickz.api.domain.draft.application.dto.response.RoomInitResponse;
@@ -77,6 +78,7 @@ public class DraftRoomController implements DraftRoomDocsController {
             @Valid @RequestBody CoachSelectionRequest request
     ) {
         draftRoomService.selectCoach(roomId, participantToken, request.coachName(), request.targetTurnOrder());
+
         return ResponseEntity.ok().build();
     }
 
@@ -86,7 +88,17 @@ public class DraftRoomController implements DraftRoomDocsController {
             @RequestHeader("X-Participant-Token") String participantToken
     ) {
         draftRoomService.startDraft(roomId, participantToken);
+
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/{roomId}/state")
+    public ResponseEntity<DraftPlayStateResponse> getDraftPlayState(
+            @PathVariable("roomId") Long roomId
+    ) {
+        DraftPlayStateResponse response = draftRoomService.getDraftPlayState(roomId);
+
+        return ResponseEntity.ok(response);
     }
 
     //    @PatchMapping("/{roomId}/settings")

--- a/api/src/main/java/team/pickz/api/domain/draft/presentation/DraftRoomController.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/presentation/DraftRoomController.java
@@ -7,13 +7,17 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import team.pickz.api.domain.draft.application.DraftRoomService;
+import team.pickz.api.domain.draft.application.dto.request.CoachSelectionRequest;
+import team.pickz.api.domain.draft.application.dto.request.DraftRoomStreamerRequest;
 import team.pickz.api.domain.draft.application.dto.request.RoomConfigureRequest;
 import team.pickz.api.domain.draft.application.dto.request.RoomInitRequest;
+import team.pickz.api.domain.draft.application.dto.response.DraftRoomStreamerResponse;
 import team.pickz.api.domain.draft.application.dto.response.ParticipantResponse;
 import team.pickz.api.domain.draft.application.dto.response.RoomInitResponse;
 import team.pickz.api.global.annotation.MemberId;
 
 import java.net.URI;
+import java.util.List;
 
 @RequiredArgsConstructor
 @RequestMapping("/drafts/rooms")
@@ -27,11 +31,7 @@ public class DraftRoomController implements DraftRoomDocsController {
             //@MemberId Long hostId,
             @Valid @RequestBody RoomInitRequest request
     ) {
-        RoomInitResponse response = draftRoomService.initRoom(
-                //hostId,
-                request.mode(),
-                request.ruleName()
-        );
+        RoomInitResponse response = draftRoomService.initRoom(request);
 
         URI location = ServletUriComponentsBuilder.fromCurrentRequest()
                 .path("/{roomId}")
@@ -39,6 +39,26 @@ public class DraftRoomController implements DraftRoomDocsController {
                 .toUri();
 
         return ResponseEntity.created(location).body(response);
+    }
+
+    @PostMapping("/{roomId}/streamers")
+    public ResponseEntity<Void> saveDraftRoomStreamers(
+            @PathVariable("roomId") Long roomId,
+            @RequestHeader("X-Participant-Token") String participantToken,
+            @Valid @RequestBody List<DraftRoomStreamerRequest> requests
+    ) {
+        draftRoomService.saveDraftRoomStreamers(roomId, participantToken, requests);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/{roomId}/streamers")
+    public ResponseEntity<DraftRoomStreamerResponse> getDraftRoomStreamers(
+            @PathVariable("roomId") Long roomId
+    ) {
+        DraftRoomStreamerResponse response = draftRoomService.getDraftRoomStreamers(roomId);
+
+        return ResponseEntity.ok(response);
     }
 
     @PostMapping("invites/{inviteCode}/participants")
@@ -50,15 +70,34 @@ public class DraftRoomController implements DraftRoomDocsController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @PatchMapping("/{roomId}/settings")
-    public ResponseEntity<Void> configureAndStartRoom(
+    @PatchMapping("/{roomId}/participants/coach")
+    public ResponseEntity<Void> selectCoach(
             @PathVariable("roomId") Long roomId,
-            @RequestHeader("X-Participant-Token") String participantToken, // 방장 토큰
-            @Valid @RequestBody RoomConfigureRequest request
+            @RequestHeader("X-Participant-Token") String participantToken,
+            @Valid @RequestBody CoachSelectionRequest request
     ) {
-        draftRoomService.configureAndStartRoom(roomId, participantToken, request);
-
-        return ResponseEntity.noContent().build();
+        draftRoomService.selectCoach(roomId, participantToken, request.coachName(), request.targetTurnOrder());
+        return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/{roomId}/start")
+    public ResponseEntity<Void> startDraft(
+            @PathVariable("roomId") Long roomId,
+            @RequestHeader("X-Participant-Token") String participantToken
+    ) {
+        draftRoomService.startDraft(roomId, participantToken);
+        return ResponseEntity.ok().build();
+    }
+
+    //    @PatchMapping("/{roomId}/settings")
+//    public ResponseEntity<Void> configureAndStartRoom(
+//            @PathVariable("roomId") Long roomId,
+//            @RequestHeader("X-Participant-Token") String participantToken, // 방장 토큰
+//            @Valid @RequestBody RoomConfigureRequest request
+//    ) {
+//        draftRoomService.configureAndStartRoom(roomId, participantToken, request);
+//
+//        return ResponseEntity.noContent().build();
+//    }
 
 }

--- a/api/src/main/java/team/pickz/api/domain/draft/presentation/DraftRoomDocsController.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/presentation/DraftRoomDocsController.java
@@ -16,6 +16,7 @@ import team.pickz.api.domain.draft.application.dto.request.CoachSelectionRequest
 import team.pickz.api.domain.draft.application.dto.request.DraftRoomStreamerRequest;
 import team.pickz.api.domain.draft.application.dto.request.RoomConfigureRequest;
 import team.pickz.api.domain.draft.application.dto.request.RoomInitRequest;
+import team.pickz.api.domain.draft.application.dto.response.DraftPlayStateResponse;
 import team.pickz.api.domain.draft.application.dto.response.DraftRoomStreamerResponse;
 import team.pickz.api.domain.draft.application.dto.response.ParticipantResponse;
 import team.pickz.api.domain.draft.application.dto.response.RoomInitResponse;
@@ -124,6 +125,19 @@ public interface DraftRoomDocsController {
 
             @Parameter(description = "방장의 참여자 토큰", in = ParameterIn.HEADER, required = true)
             @RequestHeader("X-Participant-Token") String participantToken
+    );
+
+    @Operation(
+            summary = "드래프트 게임 화면 상태 조회",
+            description = "드래프트 게임(플레이) 화면 진입 시 필요한 방 상태, 참가자(감독) 배치 정보, 스트리머 풀 등 모든 초기 설정 데이터를 한 번에 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "게임 상태 조회 성공")
+    })
+    @GetMapping("/{roomId}/state")
+    ResponseEntity<DraftPlayStateResponse> getDraftPlayState(
+            @Parameter(description = "드래프트 방 ID", example = "1")
+            @PathVariable("roomId") Long roomId
     );
 
 //    @Operation(

--- a/api/src/main/java/team/pickz/api/domain/draft/presentation/DraftRoomDocsController.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/presentation/DraftRoomDocsController.java
@@ -12,11 +12,16 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import team.pickz.api.domain.draft.application.dto.request.CoachSelectionRequest;
+import team.pickz.api.domain.draft.application.dto.request.DraftRoomStreamerRequest;
 import team.pickz.api.domain.draft.application.dto.request.RoomConfigureRequest;
 import team.pickz.api.domain.draft.application.dto.request.RoomInitRequest;
+import team.pickz.api.domain.draft.application.dto.response.DraftRoomStreamerResponse;
 import team.pickz.api.domain.draft.application.dto.response.ParticipantResponse;
 import team.pickz.api.domain.draft.application.dto.response.RoomInitResponse;
 import team.pickz.api.global.annotation.MemberId;
+
+import java.util.List;
 
 @Tag(name = "Draft Room API", description = "드래프트 관련 API")
 @RequestMapping("/drafts/rooms")
@@ -24,7 +29,7 @@ public interface DraftRoomDocsController {
 
     @Operation(
             summary = "방(대기실) 초기 생성",
-            description = "방장이 드래프트 모드와 룰을 선택하여 대기실을 초기 생성합니다. 초대 코드와 방장 토큰이 반환됩니다."
+            description = "방장이 드래프트 방식, 참가 방식, 프리셋 등을 선택하여 대기실을 초기 생성합니다. 초대 코드와 방장 토큰이 반환됩니다."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "방 생성 성공")
@@ -33,6 +38,25 @@ public interface DraftRoomDocsController {
     ResponseEntity<RoomInitResponse> initRoom(
             //@Parameter(hidden = true) @MemberId Long hostId,
             @Valid @RequestBody RoomInitRequest request
+    );
+
+    @Operation(
+            summary = "스트리머 풀 설정 (방장 전용)",
+            description = "방장이 팀 슬롯별, 라인별 스트리머 배치를 설정하여 DB에 저장합니다. 기존에 설정된 풀이 있다면 덮어씁니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "스트리머 풀 설정 성공"),
+            @ApiResponse(responseCode = "400", description = "방장이 아니거나 유효하지 않은 방 정보", content = @Content(schema = @Schema(implementation = String.class)))
+    })
+    @PostMapping("/{roomId}/streamers")
+    ResponseEntity<Void> saveDraftRoomStreamers(
+            @Parameter(description = "드래프트 방 ID", example = "1")
+            @PathVariable("roomId") Long roomId,
+
+            @Parameter(description = "방장의 참여자 토큰", in = ParameterIn.HEADER, required = true)
+            @RequestHeader("X-Participant-Token") String participantToken,
+
+            @Valid @RequestBody List<DraftRoomStreamerRequest> requests
     );
 
     @Operation(
@@ -53,23 +77,73 @@ public interface DraftRoomDocsController {
     );
 
     @Operation(
-            summary = "방 설정 완료 및 드래프트 시작",
-            description = "방장이 팀 개수, 인원 등 최종 설정을 완료하고 드래프트를 시작합니다.<br>" +
+            summary = "감독 및 픽 순서 선택",
+            description = "대기실에 들어온 참가자가 자신이 맡을 감독(팀)을 선택하여 자신의 픽 순서를 배정받습니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "감독 선택 완료"),
+            @ApiResponse(responseCode = "400", description = "이미 다른 참가자가 선택한 감독이거나 유효하지 않은 요청", content = @Content(schema = @Schema(implementation = String.class)))
+    })
+    @PatchMapping("/{roomId}/participants/coach")
+    ResponseEntity<Void> selectCoach(
+            @Parameter(description = "드래프트 방 ID", example = "1")
+            @PathVariable("roomId") Long roomId,
+
+            @Parameter(description = "참여자 토큰", in = ParameterIn.HEADER, required = true)
+            @RequestHeader("X-Participant-Token") String participantToken,
+
+            @Valid @RequestBody CoachSelectionRequest request
+    );
+
+    @Operation(
+            summary = "설정된 스트리머 풀 조회",
+            description = "라인별 스트리머 풀 데이터를 불러옵니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "스트리머 풀 조회 성공")
+    })
+    @GetMapping("/{roomId}/streamer-pool")
+    ResponseEntity<DraftRoomStreamerResponse> getDraftRoomStreamers(
+            @Parameter(description = "드래프트 방 ID", example = "1")
+            @PathVariable("roomId") Long roomId
+    );
+
+    @Operation(
+            summary = "방 설정 완료 및 드래프트 시작 (방장 전용)",
+            description = "스트리머 풀 설정과 참가자들의 감독 선택이 모두 끝난 후 방장이 드래프트를 시작합니다.<br>" +
                     "이 API 성공 시 서버에서 /topic/drafts/rooms/{roomId} 경로로 드래프트 시작 및 화면 전환 웹소켓 이벤트를 브로드캐스팅합니다."
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "204", description = "설정 완료 및 시작 성공 (데이터 반환 없음)"),
-            @ApiResponse(responseCode = "400", description = "방장이 아니거나, 유효하지 않은 설정값 (예: 인원수 불일치)", content = @Content(schema = @Schema(implementation = String.class)))
+            @ApiResponse(responseCode = "200", description = "드래프트 시작 성공"),
+            @ApiResponse(responseCode = "400", description = "방장이 아니거나, 아직 모든 참가자가 감독을 선택하지 않은 경우", content = @Content(schema = @Schema(implementation = String.class)))
     })
-    @PatchMapping("/{roomId}/settings")
-    ResponseEntity<Void> configureAndStartRoom(
+    @PostMapping("/{roomId}/start")
+    ResponseEntity<Void> startDraft(
             @Parameter(description = "드래프트 방 ID", example = "1")
             @PathVariable("roomId") Long roomId,
 
             @Parameter(description = "방장의 참여자 토큰", in = ParameterIn.HEADER, required = true)
-            @RequestHeader("X-Participant-Token") String participantToken,
-
-            @Valid @RequestBody RoomConfigureRequest request
+            @RequestHeader("X-Participant-Token") String participantToken
     );
+
+//    @Operation(
+//            summary = "방 설정 완료 및 드래프트 시작",
+//            description = "방장이 팀 개수, 인원 등 최종 설정을 완료하고 드래프트를 시작합니다.<br>" +
+//                    "이 API 성공 시 서버에서 /topic/drafts/rooms/{roomId} 경로로 드래프트 시작 및 화면 전환 웹소켓 이벤트를 브로드캐스팅합니다."
+//    )
+//    @ApiResponses({
+//            @ApiResponse(responseCode = "204", description = "설정 완료 및 시작 성공 (데이터 반환 없음)"),
+//            @ApiResponse(responseCode = "400", description = "방장이 아니거나, 유효하지 않은 설정값 (예: 인원수 불일치)", content = @Content(schema = @Schema(implementation = String.class)))
+//    })
+//    @PatchMapping("/{roomId}/settings")
+//    ResponseEntity<Void> configureAndStartRoom(
+//            @Parameter(description = "드래프트 방 ID", example = "1")
+//            @PathVariable("roomId") Long roomId,
+//
+//            @Parameter(description = "방장의 참여자 토큰", in = ParameterIn.HEADER, required = true)
+//            @RequestHeader("X-Participant-Token") String participantToken,
+//
+//            @Valid @RequestBody RoomConfigureRequest request
+//    );
 
 }


### PR DESCRIPTION
## 관련 이슈

- Closes #60 

## 작업 내용

> 이번 PR에서 작업한 내용을 작성해주세요.

- 드래프트 참여 스트리머 저장 기능 구현
- 방 설 조회 기능 구현

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 드래프트 방 생성 시 제목, 모드, 참여 방식, 프리셋 등 확장된 설정 옵션 추가
  * 감독 선택 기능 추가
  * 스트리머 풀 관리 기능 추가
  * 드래프트 플레이 상태 조회 기능 추가

* **Refactor**
  * 드래프트 방 초기화 및 시작 프로세스 개선
  * 내부 타입 체계 정리 및 패키지 구조 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->