### PR TITLE
[api] feat: 웹소켓 방 삭제 및 퇴장 기능 구현

### DIFF
--- a/api/src/main/java/team/pickz/api/domain/draft/application/DraftParticipantService.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/DraftParticipantService.java
@@ -49,14 +49,23 @@ public class DraftParticipantService {
         draftParticipantRepository.save(participant);
 
         List<DraftParticipant> participants = draftParticipantRepository.findAllByRoomId(room.getId());
-        List<String> nicknames = participants.stream()
-                .map(DraftParticipant::getNickname)
+
+        List<ParticipantResponse> participantResponses = participants.stream()
+                .map(p -> new ParticipantResponse(
+                        p.getId(),
+                        p.getRoomId(),
+                        p.getParticipantToken(), // 혹은 프론트가 필요한 필드들
+                        p.getNickname(),
+                        p.isHost(),
+                        p.getSelectedCoachName(),
+                        p.getTurnOrder(),
+                        p.isReady()
+                ))
                 .toList();
 
         ParticipantUpdateEvent event = ParticipantUpdateEvent.builder()
-                .totalCount(nicknames.size())
-                .nicknames(nicknames)
-                .newParticipant(nickname)
+                .roomId(room.getId())
+                .participants(participantResponses)
                 .build();
 
         applicationEventPublisher.publishEvent(
@@ -89,9 +98,33 @@ public class DraftParticipantService {
         }
 
         participant.selectCoach(coachName, targetTurnOrder);
+        draftParticipantRepository.flush();
 
-        // WebSocket 이벤트 발행 로직 (선택사항)
-        // applicationEventPublisher.publishEvent(...);
+        List<DraftParticipant> allParticipants = draftParticipantRepository.findAllByRoomIdOrderByTurnOrderAsc(roomId);
+
+        List<ParticipantResponse> updatedParticipants = allParticipants.stream()
+                .map(this::mapToParticipantResponse) // 위에서 만든 헬퍼 메서드 사용
+                .toList();
+
+        applicationEventPublisher.publishEvent(
+                ParticipantUpdateEvent.builder()
+                        .roomId(roomId)
+                        .participants(updatedParticipants)
+                        .build()
+        );
+    }
+
+    private ParticipantResponse mapToParticipantResponse(DraftParticipant p) {
+        return ParticipantResponse.builder()
+                .id(p.getId())
+                .roomId(p.getRoomId())
+                .participantToken(p.getParticipantToken())
+                .nickname(p.getNickname())
+                .isHost(p.isHost())
+                .selectedCoachName(p.getSelectedCoachName())
+                .turnOrder(p.getTurnOrder())
+                .isReady(p.getSelectedCoachName() != null)
+                .build();
     }
 
 }

--- a/api/src/main/java/team/pickz/api/domain/draft/application/DraftRoomService.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/DraftRoomService.java
@@ -151,14 +151,24 @@ public class DraftRoomService {
         draftParticipantRepository.delete(participant);
 
         List<DraftParticipant> remainingParticipants = draftParticipantRepository.findAllByRoomIdOrderByTurnOrderAsc(roomId);
-        List<String> nicknames = remainingParticipants.stream()
-                .map(DraftParticipant::getNickname)
+
+        List<ParticipantResponse> participantResponses = remainingParticipants.stream()
+                .map(p -> new ParticipantResponse(
+                        p.getId(),
+                        p.getRoomId(),
+                        p.getParticipantToken(), // 혹은 프론트가 필요한 필드들
+                        p.getNickname(),
+                        p.isHost(),
+                        p.getSelectedCoachName(),
+                        p.getTurnOrder(),
+                        p.isReady()
+                ))
                 .toList();
 
         applicationEventPublisher.publishEvent(
                 ParticipantUpdateEvent.builder()
                         .roomId(roomId)
-                        .nicknames(nicknames)
+                        .participants(participantResponses)
                         .build()
         );
     }

--- a/api/src/main/java/team/pickz/api/domain/draft/application/DraftRoomService.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/DraftRoomService.java
@@ -15,6 +15,7 @@ import team.pickz.api.domain.draft.domain.entity.DraftParticipant;
 import team.pickz.api.domain.draft.domain.entity.DraftRoom;
 import team.pickz.api.domain.draft.domain.repository.DraftParticipantRepository;
 import team.pickz.api.domain.draft.domain.repository.DraftRoomRepository;
+import team.pickz.api.domain.draft.domain.type.RoomStatus;
 import team.pickz.api.domain.member.domain.MemberRepository;
 
 import java.util.List;
@@ -132,11 +133,15 @@ public class DraftRoomService {
 
     @Transactional
     public void leaveRoom(Long roomId, String participantToken) {
-        DraftRoom room = draftRoomRepository.findById(roomId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 방입니다."));
+        DraftRoom room = draftRoomRepository.findById(roomId).orElse(null);
+        if (room == null || room.getStatus() == RoomStatus.DELETED) {
+            return;
+        }
 
-        DraftParticipant participant = draftParticipantRepository.findByParticipantToken(participantToken)
-                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 참여자입니다."));
+        DraftParticipant participant = draftParticipantRepository.findByParticipantToken(participantToken).orElse(null);
+        if (participant == null) {
+            return;
+        }
 
         if (participant.isHost()) {
             deleteRoom(roomId, participantToken);

--- a/api/src/main/java/team/pickz/api/domain/draft/application/DraftRoomService.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/DraftRoomService.java
@@ -7,6 +7,8 @@ import org.springframework.transaction.annotation.Transactional;
 import team.pickz.api.domain.draft.application.dto.request.RoomInitRequest;
 import team.pickz.api.domain.draft.application.dto.response.*;
 import team.pickz.api.domain.draft.application.event.DraftRoomStartedEvent;
+import team.pickz.api.domain.draft.application.event.ParticipantUpdateEvent;
+import team.pickz.api.domain.draft.application.event.RoomDeletedEvent;
 import team.pickz.api.domain.draft.application.event.RoomStatusEvent;
 import team.pickz.api.domain.draft.domain.type.ParticipationType;
 import team.pickz.api.domain.draft.domain.entity.DraftParticipant;
@@ -101,6 +103,57 @@ public class DraftRoomService {
                 DraftRoomStartedEvent.builder()
                         .roomId(roomId)
                         .payload(event)
+                        .build()
+        );
+    }
+
+    @Transactional
+    public void deleteRoom(Long roomId, String participantToken) {
+        DraftRoom room = draftRoomRepository.findById(roomId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 방입니다."));
+
+        DraftParticipant requestor = draftParticipantRepository.findByParticipantToken(participantToken)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 참여자입니다."));
+
+        if (!requestor.isHost()) {
+            throw new IllegalArgumentException("방장만 방을 삭제할 수 있습니다.");
+        }
+
+        room.delete();
+        draftRoomRepository.delete(room);
+
+        applicationEventPublisher.publishEvent(
+                RoomDeletedEvent.builder()
+                        .roomId(roomId)
+                        .message("방장이 방을 삭제했습니다.")
+                        .build()
+        );
+    }
+
+    @Transactional
+    public void leaveRoom(Long roomId, String participantToken) {
+        DraftRoom room = draftRoomRepository.findById(roomId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 방입니다."));
+
+        DraftParticipant participant = draftParticipantRepository.findByParticipantToken(participantToken)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 참여자입니다."));
+
+        if (participant.isHost()) {
+            deleteRoom(roomId, participantToken);
+            return;
+        }
+
+        draftParticipantRepository.delete(participant);
+
+        List<DraftParticipant> remainingParticipants = draftParticipantRepository.findAllByRoomIdOrderByTurnOrderAsc(roomId);
+        List<String> nicknames = remainingParticipants.stream()
+                .map(DraftParticipant::getNickname)
+                .toList();
+
+        applicationEventPublisher.publishEvent(
+                ParticipantUpdateEvent.builder()
+                        .roomId(roomId)
+                        .nicknames(nicknames)
                         .build()
         );
     }

--- a/api/src/main/java/team/pickz/api/domain/draft/application/dto/response/ParticipantResponse.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/dto/response/ParticipantResponse.java
@@ -5,11 +5,21 @@ import lombok.Builder;
 @Builder
 public record ParticipantResponse(
 
+        Long id,
+
         Long roomId,
 
         String participantToken,
 
-        boolean isHost
+        String nickname,
+
+        boolean isHost,
+
+        String selectedCoachName,
+
+        Integer turnOrder,
+
+        boolean isReady
 
 ) {
 }

--- a/api/src/main/java/team/pickz/api/domain/draft/application/event/ParticipantUpdateEvent.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/event/ParticipantUpdateEvent.java
@@ -1,19 +1,16 @@
 package team.pickz.api.domain.draft.application.event;
 
 import lombok.Builder;
+import team.pickz.api.domain.draft.application.dto.response.ParticipantResponse;
 
 import java.util.List;
 
 @Builder
 public record ParticipantUpdateEvent(
 
-        int totalCount,
-
         Long roomId,
 
-        List<String> nicknames,
-
-        String newParticipant
+        List<ParticipantResponse> participants
 
 ) {
 }

--- a/api/src/main/java/team/pickz/api/domain/draft/application/event/ParticipantUpdateEvent.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/event/ParticipantUpdateEvent.java
@@ -9,6 +9,8 @@ public record ParticipantUpdateEvent(
 
         int totalCount,
 
+        Long roomId,
+
         List<String> nicknames,
 
         String newParticipant

--- a/api/src/main/java/team/pickz/api/domain/draft/application/event/RoomDeletedEvent.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/event/RoomDeletedEvent.java
@@ -1,0 +1,9 @@
+package team.pickz.api.domain.draft.application.event;
+
+import lombok.Builder;
+
+@Builder
+public record RoomDeletedEvent(
+        Long roomId,
+        String message
+) {}

--- a/api/src/main/java/team/pickz/api/domain/draft/domain/entity/DraftParticipant.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/domain/entity/DraftParticipant.java
@@ -36,6 +36,8 @@ public class DraftParticipant {
 
     private String selectedCoachName;
 
+    private boolean isReady;
+
     @Builder
     public DraftParticipant(Long roomId, Long memberId, String nickname, boolean isHost) {
         this.roomId = roomId;
@@ -52,6 +54,9 @@ public class DraftParticipant {
     public void selectCoach(String coachName, int turnOrder) {
         this.selectedCoachName = coachName;
         this.turnOrder = turnOrder;
+        if(coachName != null) {
+            this.isReady = true;
+        }
     }
 
 }

--- a/api/src/main/java/team/pickz/api/domain/draft/domain/entity/DraftRoom.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/domain/entity/DraftRoom.java
@@ -96,4 +96,8 @@ public class DraftRoom {
         }
     }
 
+    public void delete() {
+        this.status = RoomStatus.DELETED;
+    }
+
 }

--- a/api/src/main/java/team/pickz/api/domain/draft/domain/repository/DraftParticipantRepository.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/domain/repository/DraftParticipantRepository.java
@@ -9,6 +9,8 @@ public interface DraftParticipantRepository {
 
     int countByRoomId(Long roomId);
 
+    void delete(DraftParticipant participant);
+
     List<DraftParticipant> findAllByRoomId(Long roomId);
 
     DraftParticipant save(DraftParticipant draftParticipant);

--- a/api/src/main/java/team/pickz/api/domain/draft/domain/repository/DraftParticipantRepository.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/domain/repository/DraftParticipantRepository.java
@@ -7,6 +7,8 @@ import java.util.Optional;
 
 public interface DraftParticipantRepository {
 
+    void flush();
+
     int countByRoomId(Long roomId);
 
     void delete(DraftParticipant participant);

--- a/api/src/main/java/team/pickz/api/domain/draft/domain/repository/DraftRoomRepository.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/domain/repository/DraftRoomRepository.java
@@ -9,6 +9,8 @@ public interface DraftRoomRepository {
 
     DraftRoom save(DraftRoom draftRoom);
 
+    void delete(DraftRoom draftRoom);
+
     Optional<DraftRoom> findById(Long roomId);
 
     Optional<DraftRoom> findByIdForUpdate(Long roomId);

--- a/api/src/main/java/team/pickz/api/domain/draft/domain/type/RoomStatus.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/domain/type/RoomStatus.java
@@ -3,5 +3,6 @@ package team.pickz.api.domain.draft.domain.type;
 public enum RoomStatus {
     WAITING,
     IN_PROGRESS,
-    DONE
+    DONE,
+    DELETED
 }

--- a/api/src/main/java/team/pickz/api/domain/draft/infrastructure/DraftParticipantRepositoryImpl.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/infrastructure/DraftParticipantRepositoryImpl.java
@@ -35,6 +35,11 @@ public class DraftParticipantRepositoryImpl implements DraftParticipantRepositor
     }
 
     @Override
+    public void flush() {
+        draftParticipantJpaRepository.flush();
+    }
+
+    @Override
     public int countByRoomId(Long roomId) {
         return draftParticipantJpaRepository.countByRoomId(roomId);
     }

--- a/api/src/main/java/team/pickz/api/domain/draft/infrastructure/DraftParticipantRepositoryImpl.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/infrastructure/DraftParticipantRepositoryImpl.java
@@ -40,6 +40,11 @@ public class DraftParticipantRepositoryImpl implements DraftParticipantRepositor
     }
 
     @Override
+    public void delete(DraftParticipant participant) {
+        draftParticipantJpaRepository.delete(participant);
+    }
+
+    @Override
     public List<DraftParticipant> findAllByRoomId(Long roomId) {
         return draftParticipantJpaRepository.findAllByRoomId(roomId);
     }

--- a/api/src/main/java/team/pickz/api/domain/draft/infrastructure/DraftRoomRepositoryImpl.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/infrastructure/DraftRoomRepositoryImpl.java
@@ -19,6 +19,11 @@ public class DraftRoomRepositoryImpl implements DraftRoomRepository {
     }
 
     @Override
+    public void delete(DraftRoom draftRoom) {
+        draftRoomJpaRepository.delete(draftRoom);
+    }
+
+    @Override
     public Optional<DraftRoom> findById(Long roomId) {
         return draftRoomJpaRepository.findById(roomId);
     }

--- a/api/src/main/java/team/pickz/api/domain/draft/infrastructure/websocket/DraftConnectionEventListener.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/infrastructure/websocket/DraftConnectionEventListener.java
@@ -1,0 +1,48 @@
+package team.pickz.api.domain.draft.infrastructure.websocket;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import team.pickz.api.domain.draft.application.DraftRoomService;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class DraftConnectionEventListener {
+
+    private final DraftSessionManager sessionManager;
+    private final DraftRoomService draftRoomService;
+
+    @EventListener
+    public void handleSessionConnect(SessionConnectEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+
+        String participantToken = accessor.getFirstNativeHeader("X-Participant-Token");
+        String roomIdStr = accessor.getFirstNativeHeader("roomId");
+        String sessionId = accessor.getSessionId();
+
+        if (participantToken != null && roomIdStr != null) {
+            Long roomId = Long.parseLong(roomIdStr);
+            sessionManager.addSession(sessionId, roomId, participantToken);
+        }
+    }
+
+    @EventListener
+    public void handleSessionDisconnect(SessionDisconnectEvent event) {
+        String sessionId = event.getSessionId();
+        DraftSessionManager.SessionInfo info = sessionManager.removeSession(sessionId);
+
+        if (info != null) {
+            log.info("비정상 종료 감지 - SessionId: {}, RoomId: {}", sessionId, info.roomId());
+            try {
+                draftRoomService.leaveRoom(info.roomId(), info.participantToken());
+            } catch (Exception e) {
+                log.warn("퇴장 처리 중 무시 가능한 예외 발생: {}", e.getMessage());
+            }
+        }
+    }
+}

--- a/api/src/main/java/team/pickz/api/domain/draft/infrastructure/websocket/DraftEventListener.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/infrastructure/websocket/DraftEventListener.java
@@ -1,6 +1,7 @@
 package team.pickz.api.domain.draft.infrastructure.websocket;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
@@ -8,6 +9,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 import team.pickz.api.domain.draft.application.event.DraftPickedEvent;
 import team.pickz.api.domain.draft.application.event.DraftRoomStartedEvent;
 import team.pickz.api.domain.draft.application.event.ParticipantJoinedEvent;
+import team.pickz.api.domain.draft.application.event.RoomDeletedEvent;
 
 @RequiredArgsConstructor
 @Component
@@ -31,6 +33,15 @@ public class DraftEventListener {
     public void handleRoomStarted(DraftRoomStartedEvent event) {
         messagingTemplate.convertAndSend(
                 "/topic/drafts/rooms/" + event.roomId(), event.payload());
+    }
+
+    @EventListener
+    public void handleRoomDeletedEvent(RoomDeletedEvent event) {
+        // 프론트엔드는 이 구독 채널에서 메시지를 받으면 socket.disconnect()를 호출하고 홈으로 튕겨냅니다.
+        messagingTemplate.convertAndSend(
+                "/topic/drafts/rooms/" + event.roomId() + "/deleted",
+                event
+        );
     }
 
 }

--- a/api/src/main/java/team/pickz/api/domain/draft/infrastructure/websocket/DraftSessionManager.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/infrastructure/websocket/DraftSessionManager.java
@@ -1,0 +1,22 @@
+package team.pickz.api.domain.draft.infrastructure.websocket;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class DraftSessionManager {
+
+    private final Map<String, SessionInfo> sessionMap = new ConcurrentHashMap<>();
+
+    public record SessionInfo(Long roomId, String participantToken) {}
+
+    public void addSession(String sessionId, Long roomId, String participantToken) {
+        sessionMap.put(sessionId, new SessionInfo(roomId, participantToken));
+    }
+
+    public SessionInfo removeSession(String sessionId) {
+        return sessionMap.remove(sessionId);
+    }
+}

--- a/api/src/main/java/team/pickz/api/domain/draft/presentation/DraftRoomController.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/presentation/DraftRoomController.java
@@ -105,4 +105,24 @@ public class DraftRoomController implements DraftRoomDocsController {
         return ResponseEntity.ok(response);
     }
 
+    @DeleteMapping("/{roomId}")
+    public ResponseEntity<Void> deleteRoom(
+            @PathVariable("roomId") Long roomId,
+            @RequestHeader("X-Participant-Token") String participantToken
+    ) {
+        draftRoomService.deleteRoom(roomId, participantToken);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{roomId}/participants")
+    public ResponseEntity<Void> leaveRoom(
+            @PathVariable("roomId") Long roomId,
+            @RequestHeader("X-Participant-Token") String participantToken
+    ) {
+        draftRoomService.leaveRoom(roomId, participantToken);
+
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/api/src/main/java/team/pickz/api/domain/draft/presentation/DraftRoomDocsController.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/presentation/DraftRoomDocsController.java
@@ -140,24 +140,27 @@ public interface DraftRoomDocsController {
             @PathVariable("roomId") Long roomId
     );
 
-//    @Operation(
-//            summary = "방 설정 완료 및 드래프트 시작",
-//            description = "방장이 팀 개수, 인원 등 최종 설정을 완료하고 드래프트를 시작합니다.<br>" +
-//                    "이 API 성공 시 서버에서 /topic/drafts/rooms/{roomId} 경로로 드래프트 시작 및 화면 전환 웹소켓 이벤트를 브로드캐스팅합니다."
-//    )
-//    @ApiResponses({
-//            @ApiResponse(responseCode = "204", description = "설정 완료 및 시작 성공 (데이터 반환 없음)"),
-//            @ApiResponse(responseCode = "400", description = "방장이 아니거나, 유효하지 않은 설정값 (예: 인원수 불일치)", content = @Content(schema = @Schema(implementation = String.class)))
-//    })
-//    @PatchMapping("/{roomId}/settings")
-//    ResponseEntity<Void> configureAndStartRoom(
-//            @Parameter(description = "드래프트 방 ID", example = "1")
-//            @PathVariable("roomId") Long roomId,
-//
-//            @Parameter(description = "방장의 참여자 토큰", in = ParameterIn.HEADER, required = true)
-//            @RequestHeader("X-Participant-Token") String participantToken,
-//
-//            @Valid @RequestBody RoomConfigureRequest request
-//    );
+    @Operation(
+            summary = "방 삭제 (방장 전용)",
+            description = "방장이 대기실 또는 게임을 강제 종료하고 방을 삭제합니다.<br>" +
+                    "성공 시 /topic/drafts/rooms/{roomId}/deleted 경로로 웹소켓 이벤트가 발생하여 모든 참가자의 연결을 끊습니다."
+    )
+    @DeleteMapping("/{roomId}")
+    ResponseEntity<Void> deleteRoom(
+            @PathVariable("roomId") Long roomId,
+            @RequestHeader("X-Participant-Token") String participantToken
+    );
+
+    @Operation(
+            summary = "방 퇴장 (일반 참가자 전용)",
+            description = "일반 참가자가 스스로 방에서 퇴장합니다.<br>" +
+                    "방장이 이 API를 호출하면 자동으로 방 삭제 로직으로 전환됩니다.<br>" +
+                    "성공 시 남은 인원들에게 /topic/drafts/rooms/{roomId}/participants 경로로 갱신된 인원 목록이 브로드캐스팅됩니다."
+    )
+    @DeleteMapping("/{roomId}/participants")
+    ResponseEntity<Void> leaveRoom(
+            @PathVariable("roomId") Long roomId,
+            @RequestHeader("X-Participant-Token") String participantToken
+    );
 
 }


### PR DESCRIPTION
## 관련 이슈

- Closes #65 

## 작업 내용

> 이번 PR에서 작업한 내용을 작성해주세요.

- 웹소켓 방 삭제 및 방 종료 기능 구현
- 비정상 종료 처리 기능 구현

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 방 호스트가 드래프트 방을 삭제할 수 있는 기능 추가
  * 참여자가 진행 중인 드래프트 방에서 퇴장할 수 있는 기능 추가
  * 방 삭제 및 참여자 변동 시 실시간 WebSocket 알림 기능 추가
  * WebSocket 연결 해제 시 자동 퇴장 처리 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->