### PR TITLE
[api] feat: 경매 드래프트 참가자 정보 및 이벤트 동기화 기능 추가

### DIFF
--- a/api/src/main/java/team/pickz/api/domain/draft/application/DraftParticipantService.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/DraftParticipantService.java
@@ -78,9 +78,12 @@ public class DraftParticipantService {
         );
 
         return ParticipantResponse.builder()
+                .id(participant.getId())
                 .roomId(room.getId())
                 .participantToken(participant.getParticipantToken())
+                .nickname(participant.getNickname())
                 .isHost(participant.isHost())
+                .isReady(participant.isReady())
                 .build();
     }
 

--- a/api/src/main/java/team/pickz/api/domain/draft/application/DraftParticipantService.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/DraftParticipantService.java
@@ -100,19 +100,21 @@ public class DraftParticipantService {
             throw new IllegalArgumentException("참여자가 해당 방에 속하지 않습니다.");
         }
 
-        // 동시성 처리 고려: 이미 누군가 해당 감독/순서를 골랐는지 검증
-        boolean isAlreadySelected = draftParticipantRepository.existsByRoomIdAndSelectedCoachName(roomId, coachName);
-        if (isAlreadySelected) {
-            throw new IllegalStateException("이미 다른 참가자가 선택한 감독입니다.");
+        if (coachName.equals(participant.getSelectedCoachName())) {
+        } else {
+            boolean isAlreadySelected = draftParticipantRepository.existsByRoomIdAndSelectedCoachName(roomId, coachName);
+            if (isAlreadySelected) {
+                throw new IllegalStateException("이미 다른 참가자가 선택한 감독입니다.");
+            }
+            participant.selectCoach(coachName, targetTurnOrder);
         }
 
-        participant.selectCoach(coachName, targetTurnOrder);
         draftParticipantRepository.flush();
 
         List<DraftParticipant> allParticipants = draftParticipantRepository.findAllByRoomIdOrderByTurnOrderAsc(roomId);
 
         List<ParticipantResponse> updatedParticipants = allParticipants.stream()
-                .map(this::mapToParticipantResponse) // 위에서 만든 헬퍼 메서드 사용
+                .map(this::mapToParticipantResponse)
                 .toList();
 
         applicationEventPublisher.publishEvent(

--- a/api/src/main/java/team/pickz/api/domain/draft/application/DraftParticipantService.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/DraftParticipantService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import team.pickz.api.domain.draft.application.dto.response.JoinRoomResponse;
 import team.pickz.api.domain.draft.application.dto.response.ParticipantResponse;
 import team.pickz.api.domain.draft.application.event.ParticipantJoinedEvent;
 import team.pickz.api.domain.draft.application.event.ParticipantUpdateEvent;
@@ -27,7 +28,7 @@ public class DraftParticipantService {
     private final DraftParticipantRepository draftParticipantRepository;
 
     @Transactional
-    public ParticipantResponse joinRoom(String inviteCode) {
+    public JoinRoomResponse joinRoom(String inviteCode) {
         DraftRoom room = draftRoomRepository.findByInviteCodeWithLock(inviteCode)
                 .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 초대 코드입니다."));
 
@@ -77,13 +78,16 @@ public class DraftParticipantService {
                         .build()
         );
 
-        return ParticipantResponse.builder()
-                .id(participant.getId())
+        return JoinRoomResponse.builder()
                 .roomId(room.getId())
+                .title(room.getTitle())
+                .draftMode(room.getDraftMode())
+                .participationType(room.getParticipationType())
+                .teamCount(room.getTeamCount())
                 .participantToken(participant.getParticipantToken())
                 .nickname(participant.getNickname())
                 .isHost(participant.isHost())
-                .isReady(participant.isReady())
+                .participants(participantResponses)
                 .build();
     }
 

--- a/api/src/main/java/team/pickz/api/domain/draft/application/DraftParticipantService.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/DraftParticipantService.java
@@ -2,6 +2,7 @@ package team.pickz.api.domain.draft.application;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.pickz.api.domain.draft.application.dto.response.JoinRoomResponse;
@@ -109,7 +110,11 @@ public class DraftParticipantService {
             participant.selectCoach(coachName, targetTurnOrder);
         }
 
-        draftParticipantRepository.flush();
+        try {
+            draftParticipantRepository.flush();
+        } catch (DataIntegrityViolationException e) {
+            throw new IllegalStateException("이미 다른 참가자가 선택한 감독입니다.");
+        }
 
         List<DraftParticipant> allParticipants = draftParticipantRepository.findAllByRoomIdOrderByTurnOrderAsc(roomId);
 

--- a/api/src/main/java/team/pickz/api/domain/draft/application/DraftRoomService.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/DraftRoomService.java
@@ -10,6 +10,8 @@ import team.pickz.api.domain.draft.application.event.DraftRoomStartedEvent;
 import team.pickz.api.domain.draft.application.event.ParticipantUpdateEvent;
 import team.pickz.api.domain.draft.application.event.RoomDeletedEvent;
 import team.pickz.api.domain.draft.application.event.RoomStatusEvent;
+import team.pickz.api.domain.draft.application.util.RandomNicknameGenerator;
+import team.pickz.api.domain.draft.application.util.RoomSequenceManager;
 import team.pickz.api.domain.draft.domain.type.DraftMode;
 import team.pickz.api.domain.draft.domain.type.ParticipationType;
 import team.pickz.api.domain.draft.domain.entity.DraftParticipant;
@@ -30,6 +32,7 @@ public class DraftRoomService {
     private final DraftParticipantRepository draftParticipantRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
     private final AuctionRoomService auctionRoomService;
+    private final RoomSequenceManager roomSequenceManager;
 
     @Transactional
     public RoomInitResponse initRoom(/**Long hostMemberId,**/RoomInitRequest request) {
@@ -53,10 +56,13 @@ public class DraftRoomService {
                 .build();
         draftRoomRepository.save(room);
 
+        int sequence = roomSequenceManager.getNextSequence(room.getId());
+        String hostNickname = RandomNicknameGenerator.generate(sequence);
+
         DraftParticipant host = DraftParticipant.builder()
                 .roomId(room.getId())
                 //.memberId(member.getId())
-                //.nickname(member.getNickname())
+                .nickname(hostNickname)
                 .isHost(true)
                 .build();
         draftParticipantRepository.save(host);
@@ -65,6 +71,7 @@ public class DraftRoomService {
                 .roomId(room.getId())
                 .inviteCode(room.getInviteCode())
                 .participantToken(host.getParticipantToken())
+                .nickname(host.getNickname())
                 .isHost(true)
                 .build();
     }

--- a/api/src/main/java/team/pickz/api/domain/draft/application/dto/response/JoinRoomResponse.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/dto/response/JoinRoomResponse.java
@@ -1,0 +1,31 @@
+package team.pickz.api.domain.draft.application.dto.response;
+
+import lombok.Builder;
+import team.pickz.api.domain.draft.domain.type.DraftMode;
+import team.pickz.api.domain.draft.domain.type.ParticipationType;
+
+import java.util.List;
+
+@Builder
+public record JoinRoomResponse(
+
+        Long roomId,
+
+        String title,
+
+        DraftMode draftMode,
+
+        ParticipationType participationType,
+
+        int teamCount,
+
+        String participantToken,
+
+        String nickname,
+
+        boolean isHost,
+
+        List<ParticipantResponse> participants
+
+) {
+}

--- a/api/src/main/java/team/pickz/api/domain/draft/application/dto/response/RoomInitResponse.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/application/dto/response/RoomInitResponse.java
@@ -11,6 +11,8 @@ public record RoomInitResponse(
 
         String participantToken,
 
+        String nickname,
+
         boolean isHost
 
 ) {

--- a/api/src/main/java/team/pickz/api/domain/draft/infrastructure/websocket/DraftEventListener.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/infrastructure/websocket/DraftEventListener.java
@@ -35,7 +35,7 @@ public class DraftEventListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleParticipantUpdated(ParticipantUpdateEvent event) {
         messagingTemplate.convertAndSend(
-                "/topic/drafts/rooms/" + event.roomId(), event.participants()
+                "/topic/drafts/rooms/" + event.roomId() + "/participants", event
         );
     }
 

--- a/api/src/main/java/team/pickz/api/domain/draft/infrastructure/websocket/DraftEventListener.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/infrastructure/websocket/DraftEventListener.java
@@ -6,10 +6,7 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
-import team.pickz.api.domain.draft.application.event.DraftPickedEvent;
-import team.pickz.api.domain.draft.application.event.DraftRoomStartedEvent;
-import team.pickz.api.domain.draft.application.event.ParticipantJoinedEvent;
-import team.pickz.api.domain.draft.application.event.RoomDeletedEvent;
+import team.pickz.api.domain.draft.application.event.*;
 
 @RequiredArgsConstructor
 @Component
@@ -33,6 +30,13 @@ public class DraftEventListener {
     public void handleRoomStarted(DraftRoomStartedEvent event) {
         messagingTemplate.convertAndSend(
                 "/topic/drafts/rooms/" + event.roomId(), event.payload());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleParticipantUpdated(ParticipantUpdateEvent event) {
+        messagingTemplate.convertAndSend(
+                "/topic/drafts/rooms/" + event.roomId(), event.participants()
+        );
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)

--- a/api/src/main/java/team/pickz/api/domain/draft/presentation/DraftRoomController.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/presentation/DraftRoomController.java
@@ -13,10 +13,7 @@ import team.pickz.api.domain.draft.application.dto.request.CoachSelectionRequest
 import team.pickz.api.domain.draft.application.dto.request.DraftRoomStreamerRequest;
 import team.pickz.api.domain.draft.application.dto.request.RoomConfigureRequest;
 import team.pickz.api.domain.draft.application.dto.request.RoomInitRequest;
-import team.pickz.api.domain.draft.application.dto.response.DraftPlayStateResponse;
-import team.pickz.api.domain.draft.application.dto.response.DraftRoomStreamerResponse;
-import team.pickz.api.domain.draft.application.dto.response.ParticipantResponse;
-import team.pickz.api.domain.draft.application.dto.response.RoomInitResponse;
+import team.pickz.api.domain.draft.application.dto.response.*;
 import team.pickz.api.global.annotation.MemberId;
 
 import java.net.URI;
@@ -67,10 +64,10 @@ public class DraftRoomController implements DraftRoomDocsController {
     }
 
     @PostMapping("invites/{inviteCode}/participants")
-    public ResponseEntity<ParticipantResponse> joinRoom(
+    public ResponseEntity<JoinRoomResponse> joinRoom(
             @PathVariable("inviteCode") String inviteCode
     ) {
-        ParticipantResponse response = draftParticipantService.joinRoom(inviteCode);
+        JoinRoomResponse response = draftParticipantService.joinRoom(inviteCode);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }

--- a/api/src/main/java/team/pickz/api/domain/draft/presentation/DraftRoomDocsController.java
+++ b/api/src/main/java/team/pickz/api/domain/draft/presentation/DraftRoomDocsController.java
@@ -16,10 +16,7 @@ import team.pickz.api.domain.draft.application.dto.request.CoachSelectionRequest
 import team.pickz.api.domain.draft.application.dto.request.DraftRoomStreamerRequest;
 import team.pickz.api.domain.draft.application.dto.request.RoomConfigureRequest;
 import team.pickz.api.domain.draft.application.dto.request.RoomInitRequest;
-import team.pickz.api.domain.draft.application.dto.response.DraftPlayStateResponse;
-import team.pickz.api.domain.draft.application.dto.response.DraftRoomStreamerResponse;
-import team.pickz.api.domain.draft.application.dto.response.ParticipantResponse;
-import team.pickz.api.domain.draft.application.dto.response.RoomInitResponse;
+import team.pickz.api.domain.draft.application.dto.response.*;
 import team.pickz.api.global.annotation.MemberId;
 
 import java.util.List;
@@ -72,7 +69,7 @@ public interface DraftRoomDocsController {
     })
     @SecurityRequirements(value = {})
     @PostMapping("invites/{inviteCode}/participants")
-    ResponseEntity<ParticipantResponse> joinRoom(
+    ResponseEntity<JoinRoomResponse> joinRoom(
             @Parameter(description = "초대 코드", example = "X7a9P2K")
             @PathVariable("inviteCode") String inviteCode
     );


### PR DESCRIPTION
## 관련 이슈

- Closes #73 

## 작업 내용

> 이번 PR에서 작업한 내용을 작성해주세요.

- 방장 닉네임 생성 기능 추가
- 방 입장 시 방에 대한 전체 정보와 다른 참가자들의 감독 선택 정보 반환
- 감독 선택 시 모든 참가자에게 감독 선택 이벤트 전송

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 호스트 닉네임이 자동으로 생성되어 할당됩니다.
  * 방 입장 시 방 정보와 참가자 정보를 통합하여 반환하도록 개선되었습니다.

* **버그 수정**
  * 감독 선택 시 동일한 감독을 재선택하는 경우 추가 검증을 건너뛰도록 개선되었습니다.

* **이벤트 처리**
  * 참가자 정보 업데이트 시 실시간 알림이 전송됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->